### PR TITLE
Set `collectCoverageFrom` option for jest coverage report.

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "watch:tsc": "npx tsc -b --watch",
     "test": "npm run unit-tests",
     "unit-tests": "npx jest",
-    "unit-tests-cov": "npx jest --coverage",
+    "unit-tests-cov": "npx jest --coverage --collectCoverageFrom=src/**/*.ts",
     "lezer-generator": "npx lezer-generator ./src/codeview/lang-pack/syntax.grammar -o ./src/codeview/lang-pack/syntax.ts",
     "typecheck": "npx tsc -b",
     "build": "npm run typecheck && node esbuild.mjs --minify",


### PR DESCRIPTION
### Description
Set `--collectCoverageFrom=src/**/*.ts` to only receive coverage data from the `.ts` files in the source code. Removes the coverage data from the `__tests__` folder. 

### Changes
Update npm command `unit-tests-cov` in `package.json`.
