### PR TITLE
Increase the max height of the lint panel to 25% of the viewport height

### DIFF
--- a/src/codeview/coqTheme.json
+++ b/src/codeview/coqTheme.json
@@ -27,13 +27,15 @@
 	},
   	".cm-cursor, .cm-dropCursor": {"borderLeftColor": "auto"},
 
-	".cm-panels": {"backgroundColor": "transparent", "color": "var(--vscode-list-highlightForeground)"},
-	".cm-panel-lint": {"backgroundColor": "transparent", "color": "var(--vscode-list-highlightForeground)"},
+	".cm-panels": {"color": "var(--vscode-list-highlightForeground)"},
+	".cm-panel-lint": {"backgroundColor": "var(--vscode-listFilterWidget-background)", "color": "var(--vscode-list-highlightForeground)"},
 	".cm-panel-lint > ul": {
-		"backgroundColor": "transparent", 
 		"color": "var(--wp-cm-lint-panel-foreground)",
 		"display": "flex", 
 		"flexFlow": "column"
+	},
+	".cm-panel.cm-panel-lint ul": {
+		"maxHeight": "25vh"
 	},
 	".cm-panel.cm-panel-lint ul [aria-selected]": {
 		"background-color": "var(--vscode-list-activeSelectionBackground)",


### PR DESCRIPTION
### Description
Increase the max height of the lint panel to 25% of the viewport height (in our case the height of the editor webview panel). 

Also disables the transparent background on the lint panel as this made it very difficult to read the diagnostics when partially scrolled up. 

### Changes
See relevant changes in the codemirror theme.

### Testing this PR
Do something that creates a lot of diagnostics that will show up in the editor and inspect.

## Before A
<img width="905" height="419" alt="image" src="https://github.com/user-attachments/assets/17263ca2-dc54-4609-880d-f846d2239c37" />

## After A
<img width="927" height="557" alt="image" src="https://github.com/user-attachments/assets/3cb99525-9656-478c-8c2a-3afd13f03f34" />


## Before B
<img width="928" height="383" alt="image" src="https://github.com/user-attachments/assets/45e645ba-ac3a-47e0-b385-efa3aaa13eb1" />

## After B
<img width="927" height="557" alt="image" src="https://github.com/user-attachments/assets/9c3b00b2-2ac7-472f-a61c-a80d976a2b6f" />
