### PR TITLE
Handle mousedown events

### DIFF
--- a/src/editor.ts
+++ b/src/editor.ts
@@ -232,6 +232,9 @@ export class WaterproofEditor {
 				},
 				"drop": (view, event) => {
 					event.preventDefault();
+				},
+				"mousedown": (view, event) => {
+					event.preventDefault();
 				}
 			}
 		});


### PR DESCRIPTION
### Description
Fix for Issue #39.
### Changes
Handles the DOM mousedown event so that CodeMirror doesn't, preventing the cursor from jumping to the top of the codemirror block.
### Testing this PR
Right-click in any input area in the tutorial. The cursor should not jump to the top of the codemirror block.

