### PR TITLE
Disable tooltips on hover for diagnostics in inputareas

### DIFF
--- a/src/codeview/nodeview.ts
+++ b/src/codeview/nodeview.ts
@@ -126,6 +126,7 @@ export class CodeBlockView extends EmbeddedCodeMirrorEditor {
 				// Add the linting extension for showing diagnostics (errors, warnings, etc)
 				linter(this.lintingFunction, {
 					autoPanel: inInputArea, // Only enable auto panel when this view is inside of an input area
+					tooltipFilter: inInputArea ? (() => { return []; }) : undefined, // Don't show tooltips inside of input-areas
 				}),
 				...optional, 
 				this._readOnlyCompartment.of(EditorState.readOnly.of(!this._outerView.editable)),


### PR DESCRIPTION
### Description
Disable tooltips on hover for diagnostics in inputareas

Resolves #43. 

### Changes
Add a `tooltipFilter` to the linter extension when the code cell is in an input area. The filter returns the empty set.

### Testing this PR
Create a syntax error in an input area. The red squiggly line should still show up, but on hover no tooltip should be shown.

Everything that produces a diagnostic of any level (like `Help.`) should still produce the squiggly line of the correct color but without the tooltip on hover.
