### PR TITLE
Fix exact replacement

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8868,7 +8868,8 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/semver": {
       "version": "7.7.2",

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -541,6 +541,15 @@ export class WaterproofEditor {
 		return true;
 	}
 
+	public replaceRange(startOffset: number, endOffset: number, text: string): boolean {
+        if (!this._view || !this._mapping) return false;
+        const from = this._mapping.textOffsetToPmIndex(startOffset);
+        const to = this._mapping.textOffsetToPmIndex(endOffset);
+        const tr = this._view.state.tr.insertText(text, from, to);
+        this._view.dispatch(tr);
+        return true;
+    }
+
 	/**
 	 * Toggles line numbers for all codeblocks.
 	 * @param show The editor will show line numbers in the code cells when set to `true`.


### PR DESCRIPTION
### Description
Introduces the replaceRange method in the editor, to support this kind of messages.

Should be merged together with https://github.com/impermeable/waterproof-vscode/pull/296

The change in the package-lock.json seem to auto generate. As far as I understand them, they should checked in as they get generated, but I created a separate commit, that we could revert  it.

