### PR TITLE
Add logic to handleDOMEvents to prevent math-display from opening on click

### DIFF
--- a/src/editor.ts
+++ b/src/editor.ts
@@ -218,6 +218,13 @@ export class WaterproofEditor {
 					event.preventDefault();
 				},
 				"mousedown": (view, event) => {
+					const domTarget = event.target as Node | null;
+					if (domTarget === null) { event.preventDefault(); return; }
+					
+					const posAtDomTarget = view.posAtDOM(domTarget, 0);
+					const nodeAtDomTarget = view.state.doc.resolve(posAtDomTarget).node();
+					if (nodeAtDomTarget.type === WaterproofSchema.nodes.math_display) return;
+
 					event.preventDefault();
 				}
 			}


### PR DESCRIPTION
Adds a bit of logic to the `handleDOMEvents` objects in ProseMirror that prevented math display cells from opening on click.

### Testing

Personally, I can't (and couldn't) reproduce the bug fixed by @raulTUe (which is the reason for preventing the default behaviour of "mousedown"). 

This fix should not reintroduce this problem!

To try this:
1. Put the cursor in a proof
2. Use the RMB to select the `Help.` option from the context menu.
3. Observe whether the cursor jumps to a higher place.

Adding @jim-portegies as a reviewer as I know he could reproduce the original issue.

See #40 as well.

Fixes #63.