### PR TITLE
Mapping cache text node

### DIFF
--- a/src/mapping/textUpdate.ts
+++ b/src/mapping/textUpdate.ts
@@ -1,11 +1,29 @@
 import { Mapping } from "./mapping";
 import { ParsedStep, OperationType } from "./types";
-import { TreeNode } from "./Tree";
+import { Tree, TreeNode } from "./Tree";
 import { typeFromStep } from "./helper-functions";
 import { ReplaceStep } from "prosemirror-transform";
 import { TextUpdateError, DocChange } from "../api";
 
 export class TextUpdate {
+    /**
+     * We cache the last node in which a text update happened, as it is likely that the next text update will happen in the same node
+     * Note that this is a *reference* to the node in the tree.
+     */
+    private cachedNode: TreeNode | null = null;
+
+    getNodeFromCacheOrSearch(step: ReplaceStep, tree: Tree): TreeNode | null {
+        // These checks should be okay as the tree is updated after every text update,
+        // therefore we can use the cached node bounds to check if the next text update is happening in the same node
+        if (this.cachedNode !== null &&
+                this.cachedNode.prosemirrorStart <= step.from &&
+                step.to < this.cachedNode.prosemirrorEnd) {
+            return this.cachedNode;
+        }
+        const target = tree.findNodeByProsePos(step.from);
+        this.cachedNode = target;
+        return target;
+    }
 
     /** This function is responsible for handling updates in prosemirror that happen exclusively as text edits and translating them to vscode text doc */
     textUpdate(step: ReplaceStep, mapping: Mapping) : ParsedStep {
@@ -20,7 +38,8 @@ export class TextUpdate {
 
         const tree = mapping.getMapping()
 
-        const targetCell: TreeNode | null = tree.findNodeByProsePos(step.from)
+        const targetCell = this.getNodeFromCacheOrSearch(step, tree);
+
         if (targetCell === null) throw new TextUpdateError(" Target cell is not in mapping!!! ");
 
         if (targetCell === tree.root) throw new TextUpdateError(" Text can not be inserted into the root ");

--- a/src/mapping/textUpdate.ts
+++ b/src/mapping/textUpdate.ts
@@ -5,6 +5,8 @@ import { typeFromStep } from "./helper-functions";
 import { ReplaceStep } from "prosemirror-transform";
 import { TextUpdateError, DocChange } from "../api";
 
+const supportsTextEdits = ["code", "markdown", "math_display"];
+
 export class TextUpdate {
     /**
      * We cache the last node in which a text update happened, as it is likely that the next text update will happen in the same node
@@ -17,10 +19,16 @@ export class TextUpdate {
         // therefore we can use the cached node bounds to check if the next text update is happening in the same node
         if (this.cachedNode !== null &&
                 this.cachedNode.prosemirrorStart <= step.from &&
-                step.to < this.cachedNode.prosemirrorEnd) {
+                step.to <= this.cachedNode.prosemirrorEnd) {
             return this.cachedNode;
         }
         const target = tree.findNodeByProsePos(step.from);
+        // If we have to search the tree anyway we take the time to do a sanity check
+        // for the type of node returned here. In this case we only expect a text
+        // editable node to be returned (i.e. code, markdown, or math-display)
+        if (!supportsTextEdits.includes(target?.type ?? "")) {
+            throw new TextUpdateError("When attempting to refresh the text update node cache we got a node that does not support text edits");
+        }
         this.cachedNode = target;
         return target;
     }


### PR DESCRIPTION
Cache the last node in which a text update happened, as it is likely that the next text update will happen in the same node.
This saves us from having to run our tree search algorithm on every text insertion (which in practice means every keystroke).

The only danger here is that we for some reason do not invalidate the cache and hence attempt to insert at an incorrect place, corrupting the file.

Import to note is that we always update **all** relevant ranges in the tree after a text insertion occurred. Since the cached node is a reference to a node in the tree, its ranges will also be automatically updated.

This change is also live at https://dikiedick.github.io/waterproof-browser.

### Testing
Complete some files and make sure to try every operation that deals with text (insertions (both typing and pasting), deletions, replacing (cutting and replacing by pasting)).