### PR TITLE
Make gutter opaque

### DIFF
--- a/src/codeview/coqTheme.json
+++ b/src/codeview/coqTheme.json
@@ -50,9 +50,13 @@
 	},
   
 	".cm-gutters": {
-	  "backgroundColor": "var(--wp-editorInlayHintBackground)",
+	  "backgroundColor": "var(--wp-listFilterWidgetBackground)",
 	  "color": "var(--wp-editorInlayHintForeground)",
 	  "border": "none"
+	},
+
+	".cm-gutters-after": {
+	  "backgroundColor": "var(--wp-editorInlayHintBackground)"
 	},
 
 	".cm-activeLineGutter": {


### PR DESCRIPTION
### Description
The left side gutter that contains the line numbers was transparent. This made the line numbers hard to read when scrolling to the right.

### Changes
- Changed coqTheme.json so that the left gutter has background `var(--wp-listFilterWidgetBackground)`;
- Changed coqTheme.json so that the right gutter (with the busy indicator) remains transparent.

### Testing this PR
Create a bunch of characters on one line so that it overflows on the right. Then you can scroll to right and find that the gutter with the line numbers is no longer transparent, making it more readable.

This should work both for Rocq and Lean 
<img width="771" height="178" alt="image" src="https://github.com/user-attachments/assets/c3f472af-b028-4412-af97-c691ab1de038" />

Fixes https://github.com/impermeable/waterproof-vscode/issues/311
