### PR TITLE
Implement some quality of life features in the editor

### DIFF
--- a/src/codeview/nodeview.ts
+++ b/src/codeview/nodeview.ts
@@ -1,5 +1,5 @@
-import { syntaxHighlighting } from "@codemirror/language";
-import { Completion, CompletionContext, CompletionResult, CompletionSource, autocompletion, snippet, acceptCompletion, completionStatus, hasNextSnippetField, nextSnippetField, snippetKeymap, prevSnippetField, clearSnippet, moveCompletionSelection, closeCompletion } from "@codemirror/autocomplete";
+import { bracketMatching, syntaxHighlighting } from "@codemirror/language";
+import { Completion, CompletionContext, CompletionResult, CompletionSource, autocompletion, snippet, acceptCompletion, completionStatus, hasNextSnippetField, nextSnippetField, snippetKeymap, prevSnippetField, clearSnippet, moveCompletionSelection, closeCompletion, closeBrackets } from "@codemirror/autocomplete";
 import { Compartment, EditorState, Extension } from "@codemirror/state"
 import {
 	EditorView as CodeMirror, Command, keymap as cmKeymap,
@@ -155,6 +155,8 @@ export class CodeBlockView extends EmbeddedCodeMirrorEditor {
 		this._codemirror = new CodeMirror({
 			doc: this._node.textContent,
 			extensions: [
+				bracketMatching({}),
+				closeBrackets(),
 				...this.busyIndicator.getExtensions(),
 				// Add the linting extension for showing diagnostics (errors, warnings, etc)
 				linter(this.lintingFunction, {

--- a/src/embedded-codemirror/embedded-codemirror-keymap.ts
+++ b/src/embedded-codemirror/embedded-codemirror-keymap.ts
@@ -1,4 +1,4 @@
-import { cursorGroupLeft, selectGroupLeft, cursorLineBoundaryLeft, selectLineBoundaryLeft, cursorGroupRight, selectGroupRight, cursorLineBoundaryRight, selectLineBoundaryRight, cursorDocStart, selectDocStart, cursorPageUp, selectPageUp, cursorDocEnd, selectDocEnd, cursorPageDown, selectPageDown, cursorLineBoundaryBackward, selectLineBoundaryBackward, cursorLineBoundaryForward, selectLineBoundaryForward, insertNewlineAndIndent, deleteCharBackward, deleteCharForward, deleteGroupBackward, deleteGroupForward, cursorCharLeft, cursorCharRight, cursorLineDown, cursorLineUp, selectCharLeft, selectCharRight, selectLineDown, selectLineUp, selectAll } from "@codemirror/commands";
+import { cursorGroupLeft, selectGroupLeft, cursorLineBoundaryLeft, selectLineBoundaryLeft, cursorGroupRight, selectGroupRight, cursorLineBoundaryRight, selectLineBoundaryRight, cursorDocStart, selectDocStart, cursorPageUp, selectPageUp, cursorDocEnd, selectDocEnd, cursorPageDown, selectPageDown, cursorLineBoundaryBackward, selectLineBoundaryBackward, cursorLineBoundaryForward, selectLineBoundaryForward, insertNewlineAndIndent, deleteCharBackward, deleteCharForward, deleteGroupBackward, deleteGroupForward, cursorCharLeft, cursorCharRight, cursorLineDown, cursorLineUp, selectCharLeft, selectCharRight, selectLineDown, selectLineUp, selectAll, toggleComment, moveLineDown, moveLineUp } from "@codemirror/commands";
 import { KeyBinding } from "@codemirror/view";
 import { indentUnit } from "@codemirror/language";
 import { EditorState, StateCommand, SelectionRange, ChangeSpec, Line, EditorSelection } from "@codemirror/state"
@@ -51,6 +51,11 @@ export const keybindings: KeyBinding[] = [
 
     { key: "End", run: cursorLineBoundaryForward, shift: selectLineBoundaryForward, preventDefault: true },
     { key: "Mod-End", run: cursorDocEnd, shift: selectDocEnd },
+
+    { key: "Mod-/", run: toggleComment },
+
+    { key: "Alt-ArrowDown", run: moveLineDown},
+    { key: "Alt-ArrowUp", run: moveLineUp},
 
     { key: "Enter", run: insertNewlineAndIndent },
 

--- a/src/embedded-codemirror/embeddedCodemirror.ts
+++ b/src/embedded-codemirror/embeddedCodemirror.ts
@@ -145,8 +145,11 @@ export class EmbeddedCodeMirrorEditor implements NodeView {
 				}
 				else {
 					tr.delete(offset + fromA, offset + toA);
-					offset += (toB - fromB) - (toA - fromA);
 				}
+
+				// Keep mapping from old positions (A) to the transaction's current document.
+				// Some edits (e.g. toggle comment) are represented as multiple inserts/replaces.
+				offset += (toB - fromB) - (toA - fromA);
 			});
 			if (lineDelta !== 0) tr.setMeta("lineDelta", lineDelta);
 		  	tr.setSelection(TextSelection.create(tr.doc, selFrom, selTo));

--- a/src/embedded-codemirror/embeddedCodemirror.ts
+++ b/src/embedded-codemirror/embeddedCodemirror.ts
@@ -147,7 +147,7 @@ export class EmbeddedCodeMirrorEditor implements NodeView {
 					tr.delete(offset + fromA, offset + toA);
 				}
 
-				// Keep mapping from old positions (A) to the transaction's current document.
+				// Accumulate the total offset of the changes
 				// Some edits (e.g. toggle comment) are represented as multiple inserts/replaces.
 				offset += (toB - fromB) - (toA - fromA);
 			});


### PR DESCRIPTION
Implements a collection of quality of life features in the editor that one might expect to find in a modern editor:
- `Mod-/` can now be used to comment/uncomment the selection/line.
- `Alt-ArrowUp` and `Alt-ArrowDown` can be used to 'drag' lines within a codemirror cell.
- Brackets specified in the language config of the language package are automatically closed (for example typing `(` inserts a `)` after the cursor as well).

Also fixes a bug in the way we handle codemirror changes (thanks to @XyntaxCS). 
Previously, we would (correctly) iterate through the changes but only store the offset in the `else` branch. This is fine for normal text edits, for which we iterate over a single change. For edits like commenting lines using block comments (e.g. inserting `(* ` and ` *)` around a piece of text in Rocq) we need two changes, hence we need the offset to accumulate.

There is also a companion PR in waterproof-vscode that bumps the version of codemirror-lang-verbose used to a version that includes comment information in the language package