### PR TITLE
Containers

### DIFF
--- a/__tests__/codegroup.test.ts
+++ b/__tests__/codegroup.test.ts
@@ -14,6 +14,7 @@ import { TagConfiguration } from "../src/api";
 import { wrapInContainer, wpLift } from "../src/commands";
 
 import { EditorState, NodeSelection } from "prosemirror-state";
+import { Fragment } from "prosemirror-model";
 import { WaterproofSchema } from "../src/schema";
 import { checkInputArea } from "../src/commands/command-helpers";
 
@@ -426,5 +427,157 @@ describe("checkInputArea with container nesting", () => {
         // Position 2 is inside the markdown text directly inside container
         const innerSel = { $from: doc.resolve(2) } as any;
         expect(checkInputArea(innerSel)).toBe(false);
+    });
+
+    // T3 — Regression: the original code only checked depth=1 for input nodes.
+    // This test exercises the depth>=2 branch: cursor exactly at the input boundary
+    // inside a container (depth=2, before any inner block), which was missed pre-fix.
+    test("returns true at depth 2 (cursor at input boundary inside container)", () => {
+        const mdNode = WaterproofSchema.nodes.markdown.create({}, WaterproofSchema.text("ans"));
+        const inputNode = WaterproofSchema.nodes.input.create({}, mdNode);
+        const cgNode = WaterproofSchema.nodes.container.create({name: "test"}, inputNode);
+        const doc = WaterproofSchema.nodes.doc.create({}, cgNode);
+        // pos 2: inside input (after input open token), depth=2
+        // node(1)=container, node(2)=input → checkInputArea should return true
+        const resolvedPos = doc.resolve(2);
+        expect(resolvedPos.depth).toBe(2);
+        const innerSel = { $from: resolvedPos } as any;
+        expect(checkInputArea(innerSel)).toBe(true);
+    });
+});
+
+// ============================================================
+// Regression tests for feature/codegroup bugs
+// ============================================================
+
+// T1 — Regression: wrapInContainer must not absorb the preceding newline.
+// The old implementation used tr.wrap(blockRange, ...) which, for a top-level
+// NodeSelection, caused the preceding newline to be swept inside the container.
+// The fix uses ReplaceAroundStep(sel.from, sel.to, sel.from, sel.to, ...).
+describe("wrapInContainer newline regression", () => {
+    test("newline before wrapped node stays outside container", () => {
+        // Doc: [newline, code]
+        // newline.nodeSize=1 → code is at pos 1
+        const nlNode = WaterproofSchema.nodes.newline.create();
+        const codeNode = WaterproofSchema.nodes.code.create();
+        const doc = WaterproofSchema.nodes.doc.create({}, Fragment.from([nlNode, codeNode]));
+        const state = EditorState.create({ doc });
+        const stateWithSel = state.apply(state.tr.setSelection(NodeSelection.create(state.doc, 1)));
+
+        let newState: EditorState | null = null;
+        wrapInContainer(multileanConfig)(stateWithSel, (tr) => { newState = stateWithSel.apply(tr); });
+        expect(newState).not.toBeNull();
+
+        const newDoc = newState!.doc;
+        // Buggy behaviour: newline gets absorbed → doc.childCount=1, container contains [newline, code]
+        // Fixed behaviour: doc.childCount=2, newline stays as first child
+        expect(newDoc.childCount).toBe(2);
+        expect(newDoc.child(0).type.name).toBe("newline");
+        expect(newDoc.child(1).type.name).toBe("container");
+        expect(newDoc.child(1).firstChild!.type.name).toBe("code");
+    });
+});
+
+// T2 — Regression: wrapping a container node inside another container must be rejected.
+describe("wrapInContainer container-in-container prevention", () => {
+    test("returns false when selected node is itself a container", () => {
+        const mdNode = WaterproofSchema.nodes.markdown.create({}, WaterproofSchema.text("hello"));
+        const cgNode = WaterproofSchema.nodes.container.create({name: "inner"}, mdNode);
+        const doc = WaterproofSchema.nodes.doc.create({}, cgNode);
+        const state = EditorState.create({ doc });
+        const stateWithSel = state.apply(state.tr.setSelection(NodeSelection.create(state.doc, 0)));
+        const result = wrapInContainer(multileanConfig)(stateWithSel, undefined);
+        expect(result).toBe(false);
+    });
+});
+
+// T4 — Regression: a text edit inside the container after wrapping must not corrupt the doc.
+// This exercises the position-mapping path that was broken by the old tr.wrap approach.
+describe("wrapInContainer followed by content edit", () => {
+    test("doc structure remains valid after wrap and text insert inside code", () => {
+        // Doc: [newline, code, newline]
+        const nlNode = WaterproofSchema.nodes.newline.create();
+        const codeNode = WaterproofSchema.nodes.code.create();
+        const nl2Node = WaterproofSchema.nodes.newline.create();
+        const doc = WaterproofSchema.nodes.doc.create({}, Fragment.from([nlNode, codeNode, nl2Node]));
+        const state = EditorState.create({ doc });
+        const stateWithSel = state.apply(state.tr.setSelection(NodeSelection.create(state.doc, 1)));
+
+        let wrapped: EditorState | null = null;
+        wrapInContainer(multileanConfig)(stateWithSel, (tr) => { wrapped = stateWithSel.apply(tr); });
+        expect(wrapped).not.toBeNull();
+
+        // Verify structure after wrap: [newline, container[code], newline]
+        const wrappedDoc = wrapped!.doc;
+        expect(wrappedDoc.childCount).toBe(3);
+        expect(wrappedDoc.child(0).type.name).toBe("newline");
+        expect(wrappedDoc.child(1).type.name).toBe("container");
+        expect(wrappedDoc.child(1).firstChild!.type.name).toBe("code");
+        expect(wrappedDoc.child(2).type.name).toBe("newline");
+
+        // Now insert text inside the code node (position 3: container open at 1,
+        // code open at 2, code content starts at 3).
+        const editTr = wrapped!.tr.insertText("x", 3);
+        const edited = wrapped!.apply(editTr);
+        const editedDoc = edited.doc;
+
+        // Structure must still be [newline, container[code_with_text], newline]
+        expect(editedDoc.childCount).toBe(3);
+        expect(editedDoc.child(0).type.name).toBe("newline");
+        expect(editedDoc.child(1).type.name).toBe("container");
+        expect(editedDoc.child(1).firstChild!.type.name).toBe("code");
+        expect(editedDoc.child(2).type.name).toBe("newline");
+    });
+});
+
+// T5 — Regression: wrapInContainer must return false when openRequiresNewline is true
+// and there is no preceding newline node.
+describe("wrapInContainer openRequiresNewline enforcement", () => {
+    test("returns false when container requires preceding newline but none present", () => {
+        const strictConfig: TagConfiguration = {
+            ...multileanConfig,
+            container: {
+                ...multileanConfig.container,
+                openRequiresNewline: true,
+            }
+        };
+        // Doc: [markdown, code] — no newline between them
+        const mdNode = WaterproofSchema.nodes.markdown.create({});
+        const codeNode = WaterproofSchema.nodes.code.create();
+        const doc = WaterproofSchema.nodes.doc.create({}, Fragment.from([mdNode, codeNode]));
+        const state = EditorState.create({ doc });
+        // markdown.nodeSize = 2 (empty atom), so code is at pos 2
+        const stateWithSel = state.apply(state.tr.setSelection(NodeSelection.create(state.doc, 2)));
+        const result = wrapInContainer(strictConfig)(stateWithSel, undefined);
+        expect(result).toBe(false);
+    });
+});
+
+// T6 — Regression: wpLift must lift ALL children when container has multiple inner blocks.
+describe("wpLift with multiple children", () => {
+    test("lifts all children out of container when container has multiple inner blocks", () => {
+        const mdNode = WaterproofSchema.nodes.markdown.create({}, WaterproofSchema.text("hello"));
+        const nlNode = WaterproofSchema.nodes.newline.create();
+        const codeNode = WaterproofSchema.nodes.code.create();
+        const cgNode = WaterproofSchema.nodes.container.create(
+            {name: "test"},
+            Fragment.from([mdNode, nlNode, codeNode])
+        );
+        const doc = WaterproofSchema.nodes.doc.create({}, cgNode);
+        const state = EditorState.create({ doc });
+        const stateWithSel = state.apply(state.tr.setSelection(NodeSelection.create(state.doc, 0)));
+
+        let newState: EditorState | null = null;
+        wpLift(multileanConfig)(stateWithSel, (tr) => { newState = stateWithSel.apply(tr); });
+        expect(newState).not.toBeNull();
+
+        // Container is gone; children should be at doc level
+        const newDoc = newState!.doc;
+        expect(newDoc.firstChild!.type.name).toBe("markdown");
+        // All three inner nodes (markdown, newline, code) are now direct children of doc
+        const types = Array.from({ length: newDoc.childCount }, (_, i) => newDoc.child(i).type.name);
+        expect(types).toContain("markdown");
+        expect(types).toContain("newline");
+        expect(types).toContain("code");
     });
 });

--- a/__tests__/codegroup.test.ts
+++ b/__tests__/codegroup.test.ts
@@ -1,9 +1,9 @@
 import { parse } from "../src/markdown-defaults";
 import {
     isMarkdownBlock, isCodeBlock, isHintBlock, isInputAreaBlock,
-    isMathDisplayBlock, isNewlineBlock, isCodeGroupBlock
+    isMathDisplayBlock, isNewlineBlock, isContainerBlock
 } from "../src/document/blocks";
-import { HintBlock, CodeGroupBlock } from "../src/document";
+import { HintBlock, ContainerBlock } from "../src/document";
 import { Mapping, Range, WaterproofDocument } from "../src/api";
 import { CodeBlock, InputAreaBlock, MarkdownBlock, MathDisplayBlock, NewlineBlock } from "../src/document";
 import { configuration } from "../src/markdown-defaults";
@@ -11,7 +11,8 @@ import { DefaultTagSerializer } from "../src/serialization/DocumentSerializer";
 import { constructDocument } from "../src/document";
 import { sanityCheckTree } from "./mapping/util";
 import { TagConfiguration } from "../src/api";
-import { wrapInCodeGroup, wpLift } from "../src/commands";
+import { wrapInContainer, wpLift } from "../src/commands";
+
 import { EditorState, NodeSelection } from "prosemirror-state";
 import { WaterproofSchema } from "../src/schema";
 import { checkInputArea } from "../src/commands/command-helpers";
@@ -21,8 +22,9 @@ const serializer = new DefaultTagSerializer(config);
 
 const multileanConfig: TagConfiguration = {
     ...config,
-    codeGroup: {
-        openTag: "::::multilean\n", closeTag: "\n::::",
+    container: {
+        openTag: (name: string) => `::::${name}\n`,
+        closeTag: (_name: string) => "\n::::",
         openRequiresNewline: false, closeRequiresNewline: false,
     }
 };
@@ -35,33 +37,33 @@ function createTestMapping(blocks: WaterproofDocument) {
 
 // ============================================================
 // Parsing tests — the .mv parser (statemachine.ts) does not
-// handle code_group; parsing is handled in waterproof-vscode.
+// handle container; parsing is handled in waterproof-vscode.
 // ============================================================
 
-describe("code_group parsing (not supported by .mv parser)", () => {
-    test("parser does not recognize code_group syntax", () => {
+describe("container parsing (not supported by .mv parser)", () => {
+    test("parser does not recognize container syntax", () => {
         const doc = `::::multilean
 Some markdown content
 ::::`;
         const blocks = parse(doc, { language: "lean4" });
-        // Should be parsed as plain markdown, not as a code_group
-        expect(blocks.every(b => !isCodeGroupBlock(b))).toBe(true);
+        // Should be parsed as plain markdown, not as a container
+        expect(blocks.every(b => !isContainerBlock(b))).toBe(true);
         expect(isMarkdownBlock(blocks[0])).toBe(true);
     });
 });
 
 // ============================================================
-// Serialization tests — with empty tags, code_group serializes
+// Serialization tests — with empty tags, container serializes
 // transparently (just the inner content, no wrapper).
 // ============================================================
 
-describe("code_group serialization", () => {
-    test("serialize code_group with markdown", () => {
+describe("container serialization", () => {
+    test("serialize container with markdown", () => {
         const innerBlocks = [
             new MarkdownBlock("Some text", { from: 14, to: 23 }, { from: 14, to: 23 }, 0)
         ];
-        const cg = new CodeGroupBlock(
-            "Some text",
+        const cg = new ContainerBlock(
+            "Some text", "test",
             { from: 0, to: 28 }, { from: 14, to: 23 }, 0,
             innerBlocks
         );
@@ -70,12 +72,12 @@ describe("code_group serialization", () => {
         expect(result).toBe("Some text");
     });
 
-    test("serialize code_group with code block", () => {
+    test("serialize container with code block", () => {
         const innerBlocks = [
             new CodeBlock("def x := 1", { from: 14, to: 37 }, { from: 21, to: 31 }, 0)
         ];
-        const cg = new CodeGroupBlock(
-            "```lean4\ndef x := 1\n```",
+        const cg = new ContainerBlock(
+            "```lean4\ndef x := 1\n```", "test",
             { from: 0, to: 42 }, { from: 14, to: 37 }, 0,
             innerBlocks
         );
@@ -84,7 +86,7 @@ describe("code_group serialization", () => {
         expect(result).toBe("```lean4\ndef x := 1\n```");
     });
 
-    test("serialize code_group with input area", () => {
+    test("serialize container with input area", () => {
         const inputInnerBlocks = [
             new MarkdownBlock("input text", { from: 26, to: 36 }, { from: 26, to: 36 }, 0)
         ];
@@ -95,8 +97,8 @@ describe("code_group serialization", () => {
                 inputInnerBlocks
             )
         ];
-        const cg = new CodeGroupBlock(
-            "<input-area>input text</input-area>",
+        const cg = new ContainerBlock(
+            "<input-area>input text</input-area>", "test",
             { from: 0, to: 54 }, { from: 14, to: 49 }, 0,
             innerBlocks
         );
@@ -105,7 +107,7 @@ describe("code_group serialization", () => {
         expect(result).toBe("<input-area>input text</input-area>");
     });
 
-    test("serialize code_group with hint", () => {
+    test("serialize container with hint", () => {
         const hintInnerBlocks = [
             new MarkdownBlock("hint text", { from: 40, to: 49 }, { from: 40, to: 49 }, 0)
         ];
@@ -117,8 +119,8 @@ describe("code_group serialization", () => {
                 hintInnerBlocks
             )
         ];
-        const cg = new CodeGroupBlock(
-            '<hint title="My Hint">hint text</hint>',
+        const cg = new ContainerBlock(
+            '<hint title="My Hint">hint text</hint>', "test",
             { from: 0, to: 61 }, { from: 14, to: 52 }, 0,
             innerBlocks
         );
@@ -127,12 +129,12 @@ describe("code_group serialization", () => {
         expect(result).toBe('<hint title="My Hint">hint text</hint>');
     });
 
-    test("serialize code_group with math_display", () => {
+    test("serialize container with math_display", () => {
         const innerBlocks = [
             new MathDisplayBlock("x^2", { from: 14, to: 21 }, { from: 16, to: 19 }, 0)
         ];
-        const cg = new CodeGroupBlock(
-            "$$x^2$$",
+        const cg = new ContainerBlock(
+            "$$x^2$$", "test",
             { from: 0, to: 26 }, { from: 14, to: 21 }, 0,
             innerBlocks
         );
@@ -141,12 +143,12 @@ describe("code_group serialization", () => {
         expect(result).toBe("$$x^2$$");
     });
 
-    test("serialize code_group with non-empty tags (multilean)", () => {
+    test("serialize container with non-empty tags (multilean)", () => {
         const innerBlocks = [
             new MarkdownBlock("Some content", { from: 14, to: 26 }, { from: 14, to: 26 }, 0)
         ];
-        const cg = new CodeGroupBlock(
-            "Some content",
+        const cg = new ContainerBlock(
+            "Some content", "multilean",
             { from: 0, to: 31 }, { from: 14, to: 26 }, 0,
             innerBlocks
         );
@@ -155,13 +157,13 @@ describe("code_group serialization", () => {
         expect(result).toBe("::::multilean\nSome content\n::::");
     });
 
-    test("serialize code_group with multiple children", () => {
+    test("serialize container with multiple children", () => {
         const innerBlocks = [
             new MarkdownBlock("intro", { from: 14, to: 19 }, { from: 14, to: 19 }, 0),
             new CodeBlock("def x := 1", { from: 19, to: 42 }, { from: 26, to: 36 }, 0),
         ];
-        const cg = new CodeGroupBlock(
-            "intro```lean4\ndef x := 1\n```",
+        const cg = new ContainerBlock(
+            "intro```lean4\ndef x := 1\n```", "test",
             { from: 0, to: 47 }, { from: 14, to: 42 }, 0,
             innerBlocks
         );
@@ -175,10 +177,10 @@ describe("code_group serialization", () => {
 // Mapping tests
 // ============================================================
 
-describe("code_group mapping", () => {
-    test("mapping with code_group containing markdown", () => {
-        const cg = new CodeGroupBlock(
-            "Hello",
+describe("container mapping", () => {
+    test("mapping with container containing markdown", () => {
+        const cg = new ContainerBlock(
+            "Hello", "test",
             { from: 0, to: 24 },
             { from: 14, to: 19 },
             0,
@@ -188,22 +190,22 @@ describe("code_group mapping", () => {
 
         expect(tree.root.children.length).toBe(1);
         const cgNode = tree.root.children[0];
-        expect(cgNode.type).toBe("code_group");
+        expect(cgNode.type).toBe("container");
         expect(cgNode.children.length).toBe(1);
         expect(cgNode.children[0].type).toBe("markdown");
 
         sanityCheckTree(tree.root);
     });
 
-    test("mapping with code_group containing input area with code", () => {
+    test("mapping with container containing input area with code", () => {
         const codeInner = new CodeBlock("code", { from: 12, to: 25 }, { from: 19, to: 23 }, 0);
         const inputInner = new InputAreaBlock(
             "```lean4\ncode\n```",
             { from: 0, to: 38 }, { from: 12, to: 25 }, 0,
             [codeInner]
         );
-        const cg = new CodeGroupBlock(
-            "<input-area>```lean4\ncode\n```</input-area>",
+        const cg = new ContainerBlock(
+            "<input-area>```lean4\ncode\n```</input-area>", "test",
             { from: 0, to: 43 }, { from: 0, to: 38 }, 0,
             [inputInner]
         );
@@ -212,7 +214,7 @@ describe("code_group mapping", () => {
 
         expect(tree.root.children.length).toBe(1);
         const cgNode = tree.root.children[0];
-        expect(cgNode.type).toBe("code_group");
+        expect(cgNode.type).toBe("container");
         expect(cgNode.children.length).toBe(1);
 
         const inputNode = cgNode.children[0];
@@ -221,7 +223,7 @@ describe("code_group mapping", () => {
         sanityCheckTree(tree.root);
     });
 
-    test("mapping with code_group containing hint", () => {
+    test("mapping with container containing hint", () => {
         const hintInnerBlocks = [
             new MarkdownBlock("hint body", { from: 36, to: 45 }, { from: 36, to: 45 }, 0)
         ];
@@ -233,8 +235,8 @@ describe("code_group mapping", () => {
             0,
             hintInnerBlocks
         );
-        const cg = new CodeGroupBlock(
-            '<hint title="Test">hint body</hint>',
+        const cg = new ContainerBlock(
+            '<hint title="Test">hint body</hint>', "test",
             { from: 0, to: 57 },
             { from: 14, to: 52 },
             0,
@@ -243,7 +245,7 @@ describe("code_group mapping", () => {
         const tree = createTestMapping([cg]);
 
         const cgNode = tree.root.children[0];
-        expect(cgNode.type).toBe("code_group");
+        expect(cgNode.type).toBe("container");
         expect(cgNode.children.length).toBe(1);
 
         const hintNode = cgNode.children[0];
@@ -260,38 +262,38 @@ describe("code_group mapping", () => {
 // ProseMirror document construction tests
 // ============================================================
 
-describe("code_group ProseMirror construction", () => {
-    test("constructDocument with code_group", () => {
+describe("container ProseMirror construction", () => {
+    test("constructDocument with container", () => {
         const innerBlocks = [
             new MarkdownBlock("text", { from: 14, to: 18 }, { from: 14, to: 18 }, 0)
         ];
-        const cg = new CodeGroupBlock(
-            "text", { from: 0, to: 23 }, { from: 14, to: 18 }, 0, innerBlocks
+        const cg = new ContainerBlock(
+            "text", "test", { from: 0, to: 23 }, { from: 14, to: 18 }, 0, innerBlocks
         );
         const doc = constructDocument([cg]);
         expect(doc.type.name).toBe("doc");
         expect(doc.content.childCount).toBe(1);
-        expect(doc.content.firstChild!.type.name).toBe("code_group");
+        expect(doc.content.firstChild!.type.name).toBe("container");
         expect(doc.content.firstChild!.content.childCount).toBe(1);
         expect(doc.content.firstChild!.content.firstChild!.type.name).toBe("markdown");
     });
 
-    test("constructDocument with code_group containing input", () => {
+    test("constructDocument with container containing input", () => {
         const inputInner = [
             new MarkdownBlock("answer", { from: 26, to: 32 }, { from: 26, to: 32 }, 0)
         ];
         const input = new InputAreaBlock(
             "answer", { from: 14, to: 45 }, { from: 26, to: 32 }, 0, inputInner
         );
-        const cg = new CodeGroupBlock(
-            "<input-area>answer</input-area>",
+        const cg = new ContainerBlock(
+            "<input-area>answer</input-area>", "test",
             { from: 0, to: 50 }, { from: 14, to: 45 }, 0,
             [input]
         );
         const doc = constructDocument([cg]);
 
         const cgNode = doc.content.firstChild!;
-        expect(cgNode.type.name).toBe("code_group");
+        expect(cgNode.type.name).toBe("container");
         expect(cgNode.content.childCount).toBe(1);
 
         const inputNode = cgNode.content.firstChild!;
@@ -305,10 +307,10 @@ describe("code_group ProseMirror construction", () => {
 // Typeguard tests
 // ============================================================
 
-describe("code_group typeguard", () => {
-    test("isCodeGroupBlock identifies correctly", () => {
-        const cg = new CodeGroupBlock("", { from: 0, to: 0 }, { from: 0, to: 0 }, 0, []);
-        expect(isCodeGroupBlock(cg)).toBe(true);
+describe("container typeguard", () => {
+    test("isContainerBlock identifies correctly", () => {
+        const cg = new ContainerBlock("", "test", { from: 0, to: 0 }, { from: 0, to: 0 }, 0, []);
+        expect(isContainerBlock(cg)).toBe(true);
         expect(isInputAreaBlock(cg)).toBe(false);
         expect(isHintBlock(cg)).toBe(false);
         expect(isCodeBlock(cg)).toBe(false);
@@ -319,19 +321,19 @@ describe("code_group typeguard", () => {
 });
 
 // ============================================================
-// Rocq context tests (code_group serializes transparently)
+// Rocq context tests (container serializes transparently)
 // ============================================================
 
-describe("code_group Rocq context", () => {
-    test("serializer serializes code_group transparently in Rocq config", () => {
+describe("container Rocq context", () => {
+    test("serializer serializes container transparently in Rocq config", () => {
         const rocqConfig = configuration("coq");
         const rocqSerializer = new DefaultTagSerializer(rocqConfig);
 
         const innerBlocks = [
             new MarkdownBlock("text", { from: 14, to: 18 }, { from: 14, to: 18 }, 0)
         ];
-        const cg = new CodeGroupBlock(
-            "text", { from: 0, to: 23 }, { from: 14, to: 18 }, 0, innerBlocks
+        const cg = new ContainerBlock(
+            "text", "test", { from: 0, to: 23 }, { from: 14, to: 18 }, 0, innerBlocks
         );
         const doc = constructDocument([cg]);
         const result = rocqSerializer.serializeDocument(doc);
@@ -346,7 +348,7 @@ describe("code_group Rocq context", () => {
 /**
  * @jest-environment jsdom
  */
-describe("wrapInCodeGroup command", () => {
+describe("wrapInContainer command", () => {
     function makeStateWithMarkdown(): EditorState {
         const mdNode = WaterproofSchema.nodes.markdown.create({}, WaterproofSchema.text("hello"));
         const doc = WaterproofSchema.nodes.doc.create({}, mdNode);
@@ -355,33 +357,33 @@ describe("wrapInCodeGroup command", () => {
         return state.apply(state.tr.setSelection(NodeSelection.create(state.doc, 0)));
     }
 
-    test("wrapInCodeGroup wraps selected node in a code_group", () => {
+    test("wrapInContainer wraps selected node in a container", () => {
         const state = makeStateWithMarkdown();
         let newState: EditorState | null = null;
-        const cmd = wrapInCodeGroup(config);
+        const cmd = wrapInContainer(config);
         cmd(state, (tr) => { newState = state.apply(tr); });
 
         expect(newState).not.toBeNull();
         const doc = newState!.doc;
-        expect(doc.firstChild!.type.name).toBe("code_group");
+        expect(doc.firstChild!.type.name).toBe("container");
         expect(doc.firstChild!.firstChild!.type.name).toBe("markdown");
     });
 
-    test("wrapInCodeGroup dry-run (no dispatch) returns true when node is selected", () => {
+    test("wrapInContainer dry-run (no dispatch) returns true when node is selected", () => {
         // Per ProseMirror convention, returning true without dispatch means "I can execute".
         const state = makeStateWithMarkdown();
-        const cmd = wrapInCodeGroup(config);
+        const cmd = wrapInContainer(config);
         const result = cmd(state, undefined);
         expect(result).toBe(true);
     });
 });
 
-describe("wpLift from code_group", () => {
-    test("wpLift lifts child out of code_group", () => {
+describe("wpLift from container", () => {
+    test("wpLift lifts child out of container", () => {
         const mdNode = WaterproofSchema.nodes.markdown.create({}, WaterproofSchema.text("hello"));
-        const cgNode = WaterproofSchema.nodes.code_group.create({}, mdNode);
+        const cgNode = WaterproofSchema.nodes.container.create({name: "test"}, mdNode);
         const doc = WaterproofSchema.nodes.doc.create({}, cgNode);
-        // Select the code_group node
+        // Select the container node
         const state = EditorState.create({ doc });
         const stateWithSel = state.apply(state.tr.setSelection(NodeSelection.create(state.doc, 0)));
 
@@ -390,19 +392,19 @@ describe("wpLift from code_group", () => {
         cmd(stateWithSel, (tr) => { newState = stateWithSel.apply(tr); });
 
         expect(newState).not.toBeNull();
-        // After lifting, the markdown should be at doc level (no code_group wrapper)
+        // After lifting, the markdown should be at doc level (no container wrapper)
         expect(newState!.doc.firstChild!.type.name).toBe("markdown");
     });
 });
 
-describe("checkInputArea with code_group nesting", () => {
-    test("returns true when selection is inside input nested in code_group", () => {
+describe("checkInputArea with container nesting", () => {
+    test("returns true when selection is inside input nested in container", () => {
         const mdNode = WaterproofSchema.nodes.markdown.create({}, WaterproofSchema.text("ans"));
         const inputNode = WaterproofSchema.nodes.input.create({}, mdNode);
-        const cgNode = WaterproofSchema.nodes.code_group.create({}, inputNode);
+        const cgNode = WaterproofSchema.nodes.container.create({name: "test"}, inputNode);
         const doc = WaterproofSchema.nodes.doc.create({}, cgNode);
         const state = EditorState.create({ doc });
-        // Position 3 is inside the markdown text inside input inside code_group
+        // Position 3 is inside the markdown text inside input inside container
         const resolvedPos = doc.resolve(3);
         const sel = state.tr.setSelection(
             // Text selection inside the markdown node
@@ -411,17 +413,17 @@ describe("checkInputArea with code_group nesting", () => {
                 : state.tr.selection
         ).selection;
         // Manually test checkInputArea with the resolved position inside the input
-        // depth: doc(0) > code_group(1) > input(2) > markdown(3) > text
-        // from.node(1) = code_group, from.node(2) = input → should return true
+        // depth: doc(0) > container(1) > input(2) > markdown(3) > text
+        // from.node(1) = container, from.node(2) = input → should return true
         const innerSel = { $from: doc.resolve(3) } as any;
         expect(checkInputArea(innerSel)).toBe(true);
     });
 
-    test("returns false when selection is in markdown directly inside code_group (no input)", () => {
+    test("returns false when selection is in markdown directly inside container (no input)", () => {
         const mdNode = WaterproofSchema.nodes.markdown.create({}, WaterproofSchema.text("ans"));
-        const cgNode = WaterproofSchema.nodes.code_group.create({}, mdNode);
+        const cgNode = WaterproofSchema.nodes.container.create({name: "test"}, mdNode);
         const doc = WaterproofSchema.nodes.doc.create({}, cgNode);
-        // Position 2 is inside the markdown text directly inside code_group
+        // Position 2 is inside the markdown text directly inside container
         const innerSel = { $from: doc.resolve(2) } as any;
         expect(checkInputArea(innerSel)).toBe(false);
     });

--- a/__tests__/codegroup.test.ts
+++ b/__tests__/codegroup.test.ts
@@ -1,0 +1,428 @@
+import { parse } from "../src/markdown-defaults";
+import {
+    isMarkdownBlock, isCodeBlock, isHintBlock, isInputAreaBlock,
+    isMathDisplayBlock, isNewlineBlock, isCodeGroupBlock
+} from "../src/document/blocks";
+import { HintBlock, CodeGroupBlock } from "../src/document";
+import { Mapping, Range, WaterproofDocument } from "../src/api";
+import { CodeBlock, InputAreaBlock, MarkdownBlock, MathDisplayBlock, NewlineBlock } from "../src/document";
+import { configuration } from "../src/markdown-defaults";
+import { DefaultTagSerializer } from "../src/serialization/DocumentSerializer";
+import { constructDocument } from "../src/document";
+import { sanityCheckTree } from "./mapping/util";
+import { TagConfiguration } from "../src/api";
+import { wrapInCodeGroup, wpLift } from "../src/commands";
+import { EditorState, NodeSelection } from "prosemirror-state";
+import { WaterproofSchema } from "../src/schema";
+import { checkInputArea } from "../src/commands/command-helpers";
+
+const config = configuration("lean4");
+const serializer = new DefaultTagSerializer(config);
+
+const multileanConfig: TagConfiguration = {
+    ...config,
+    codeGroup: {
+        openTag: "::::multilean\n", closeTag: "\n::::",
+        openRequiresNewline: false, closeRequiresNewline: false,
+    }
+};
+const multileanSerializer = new DefaultTagSerializer(multileanConfig);
+
+function createTestMapping(blocks: WaterproofDocument) {
+    const mapping = new Mapping(blocks, 1, config, serializer);
+    return mapping.getMapping();
+}
+
+// ============================================================
+// Parsing tests — the .mv parser (statemachine.ts) does not
+// handle code_group; parsing is handled in waterproof-vscode.
+// ============================================================
+
+describe("code_group parsing (not supported by .mv parser)", () => {
+    test("parser does not recognize code_group syntax", () => {
+        const doc = `::::multilean
+Some markdown content
+::::`;
+        const blocks = parse(doc, { language: "lean4" });
+        // Should be parsed as plain markdown, not as a code_group
+        expect(blocks.every(b => !isCodeGroupBlock(b))).toBe(true);
+        expect(isMarkdownBlock(blocks[0])).toBe(true);
+    });
+});
+
+// ============================================================
+// Serialization tests — with empty tags, code_group serializes
+// transparently (just the inner content, no wrapper).
+// ============================================================
+
+describe("code_group serialization", () => {
+    test("serialize code_group with markdown", () => {
+        const innerBlocks = [
+            new MarkdownBlock("Some text", { from: 14, to: 23 }, { from: 14, to: 23 }, 0)
+        ];
+        const cg = new CodeGroupBlock(
+            "Some text",
+            { from: 0, to: 28 }, { from: 14, to: 23 }, 0,
+            innerBlocks
+        );
+        const doc = constructDocument([cg]);
+        const result = serializer.serializeDocument(doc);
+        expect(result).toBe("Some text");
+    });
+
+    test("serialize code_group with code block", () => {
+        const innerBlocks = [
+            new CodeBlock("def x := 1", { from: 14, to: 37 }, { from: 21, to: 31 }, 0)
+        ];
+        const cg = new CodeGroupBlock(
+            "```lean4\ndef x := 1\n```",
+            { from: 0, to: 42 }, { from: 14, to: 37 }, 0,
+            innerBlocks
+        );
+        const doc = constructDocument([cg]);
+        const result = serializer.serializeDocument(doc);
+        expect(result).toBe("```lean4\ndef x := 1\n```");
+    });
+
+    test("serialize code_group with input area", () => {
+        const inputInnerBlocks = [
+            new MarkdownBlock("input text", { from: 26, to: 36 }, { from: 26, to: 36 }, 0)
+        ];
+        const innerBlocks = [
+            new InputAreaBlock(
+                "input text",
+                { from: 14, to: 49 }, { from: 26, to: 36 }, 0,
+                inputInnerBlocks
+            )
+        ];
+        const cg = new CodeGroupBlock(
+            "<input-area>input text</input-area>",
+            { from: 0, to: 54 }, { from: 14, to: 49 }, 0,
+            innerBlocks
+        );
+        const doc = constructDocument([cg]);
+        const result = serializer.serializeDocument(doc);
+        expect(result).toBe("<input-area>input text</input-area>");
+    });
+
+    test("serialize code_group with hint", () => {
+        const hintInnerBlocks = [
+            new MarkdownBlock("hint text", { from: 40, to: 49 }, { from: 40, to: 49 }, 0)
+        ];
+        const innerBlocks = [
+            new HintBlock(
+                "hint text",
+                "My Hint",
+                { from: 14, to: 56 }, { from: 40, to: 49 }, 0,
+                hintInnerBlocks
+            )
+        ];
+        const cg = new CodeGroupBlock(
+            '<hint title="My Hint">hint text</hint>',
+            { from: 0, to: 61 }, { from: 14, to: 52 }, 0,
+            innerBlocks
+        );
+        const doc = constructDocument([cg]);
+        const result = serializer.serializeDocument(doc);
+        expect(result).toBe('<hint title="My Hint">hint text</hint>');
+    });
+
+    test("serialize code_group with math_display", () => {
+        const innerBlocks = [
+            new MathDisplayBlock("x^2", { from: 14, to: 21 }, { from: 16, to: 19 }, 0)
+        ];
+        const cg = new CodeGroupBlock(
+            "$$x^2$$",
+            { from: 0, to: 26 }, { from: 14, to: 21 }, 0,
+            innerBlocks
+        );
+        const doc = constructDocument([cg]);
+        const result = serializer.serializeDocument(doc);
+        expect(result).toBe("$$x^2$$");
+    });
+
+    test("serialize code_group with non-empty tags (multilean)", () => {
+        const innerBlocks = [
+            new MarkdownBlock("Some content", { from: 14, to: 26 }, { from: 14, to: 26 }, 0)
+        ];
+        const cg = new CodeGroupBlock(
+            "Some content",
+            { from: 0, to: 31 }, { from: 14, to: 26 }, 0,
+            innerBlocks
+        );
+        const doc = constructDocument([cg]);
+        const result = multileanSerializer.serializeDocument(doc);
+        expect(result).toBe("::::multilean\nSome content\n::::");
+    });
+
+    test("serialize code_group with multiple children", () => {
+        const innerBlocks = [
+            new MarkdownBlock("intro", { from: 14, to: 19 }, { from: 14, to: 19 }, 0),
+            new CodeBlock("def x := 1", { from: 19, to: 42 }, { from: 26, to: 36 }, 0),
+        ];
+        const cg = new CodeGroupBlock(
+            "intro```lean4\ndef x := 1\n```",
+            { from: 0, to: 47 }, { from: 14, to: 42 }, 0,
+            innerBlocks
+        );
+        const doc = constructDocument([cg]);
+        const result = serializer.serializeDocument(doc);
+        expect(result).toBe("intro```lean4\ndef x := 1\n```");
+    });
+});
+
+// ============================================================
+// Mapping tests
+// ============================================================
+
+describe("code_group mapping", () => {
+    test("mapping with code_group containing markdown", () => {
+        const cg = new CodeGroupBlock(
+            "Hello",
+            { from: 0, to: 24 },
+            { from: 14, to: 19 },
+            0,
+            [new MarkdownBlock("Hello", { from: 14, to: 19 }, { from: 14, to: 19 }, 0)]
+        );
+        const tree = createTestMapping([cg]);
+
+        expect(tree.root.children.length).toBe(1);
+        const cgNode = tree.root.children[0];
+        expect(cgNode.type).toBe("code_group");
+        expect(cgNode.children.length).toBe(1);
+        expect(cgNode.children[0].type).toBe("markdown");
+
+        sanityCheckTree(tree.root);
+    });
+
+    test("mapping with code_group containing input area with code", () => {
+        const codeInner = new CodeBlock("code", { from: 12, to: 25 }, { from: 19, to: 23 }, 0);
+        const inputInner = new InputAreaBlock(
+            "```lean4\ncode\n```",
+            { from: 0, to: 38 }, { from: 12, to: 25 }, 0,
+            [codeInner]
+        );
+        const cg = new CodeGroupBlock(
+            "<input-area>```lean4\ncode\n```</input-area>",
+            { from: 0, to: 43 }, { from: 0, to: 38 }, 0,
+            [inputInner]
+        );
+
+        const tree = createTestMapping([cg]);
+
+        expect(tree.root.children.length).toBe(1);
+        const cgNode = tree.root.children[0];
+        expect(cgNode.type).toBe("code_group");
+        expect(cgNode.children.length).toBe(1);
+
+        const inputNode = cgNode.children[0];
+        expect(inputNode.type).toBe("input");
+
+        sanityCheckTree(tree.root);
+    });
+
+    test("mapping with code_group containing hint", () => {
+        const hintInnerBlocks = [
+            new MarkdownBlock("hint body", { from: 36, to: 45 }, { from: 36, to: 45 }, 0)
+        ];
+        const hintBlock = new HintBlock(
+            "hint body",
+            "Test",
+            { from: 14, to: 52 },
+            { from: 36, to: 45 },
+            0,
+            hintInnerBlocks
+        );
+        const cg = new CodeGroupBlock(
+            '<hint title="Test">hint body</hint>',
+            { from: 0, to: 57 },
+            { from: 14, to: 52 },
+            0,
+            [hintBlock]
+        );
+        const tree = createTestMapping([cg]);
+
+        const cgNode = tree.root.children[0];
+        expect(cgNode.type).toBe("code_group");
+        expect(cgNode.children.length).toBe(1);
+
+        const hintNode = cgNode.children[0];
+        expect(hintNode.type).toBe("hint");
+        expect(hintNode.title).toBe("Test");
+        expect(hintNode.children.length).toBe(1);
+        expect(hintNode.children[0].type).toBe("markdown");
+
+        sanityCheckTree(tree.root);
+    });
+});
+
+// ============================================================
+// ProseMirror document construction tests
+// ============================================================
+
+describe("code_group ProseMirror construction", () => {
+    test("constructDocument with code_group", () => {
+        const innerBlocks = [
+            new MarkdownBlock("text", { from: 14, to: 18 }, { from: 14, to: 18 }, 0)
+        ];
+        const cg = new CodeGroupBlock(
+            "text", { from: 0, to: 23 }, { from: 14, to: 18 }, 0, innerBlocks
+        );
+        const doc = constructDocument([cg]);
+        expect(doc.type.name).toBe("doc");
+        expect(doc.content.childCount).toBe(1);
+        expect(doc.content.firstChild!.type.name).toBe("code_group");
+        expect(doc.content.firstChild!.content.childCount).toBe(1);
+        expect(doc.content.firstChild!.content.firstChild!.type.name).toBe("markdown");
+    });
+
+    test("constructDocument with code_group containing input", () => {
+        const inputInner = [
+            new MarkdownBlock("answer", { from: 26, to: 32 }, { from: 26, to: 32 }, 0)
+        ];
+        const input = new InputAreaBlock(
+            "answer", { from: 14, to: 45 }, { from: 26, to: 32 }, 0, inputInner
+        );
+        const cg = new CodeGroupBlock(
+            "<input-area>answer</input-area>",
+            { from: 0, to: 50 }, { from: 14, to: 45 }, 0,
+            [input]
+        );
+        const doc = constructDocument([cg]);
+
+        const cgNode = doc.content.firstChild!;
+        expect(cgNode.type.name).toBe("code_group");
+        expect(cgNode.content.childCount).toBe(1);
+
+        const inputNode = cgNode.content.firstChild!;
+        expect(inputNode.type.name).toBe("input");
+        expect(inputNode.content.childCount).toBe(1);
+        expect(inputNode.content.firstChild!.type.name).toBe("markdown");
+    });
+});
+
+// ============================================================
+// Typeguard tests
+// ============================================================
+
+describe("code_group typeguard", () => {
+    test("isCodeGroupBlock identifies correctly", () => {
+        const cg = new CodeGroupBlock("", { from: 0, to: 0 }, { from: 0, to: 0 }, 0, []);
+        expect(isCodeGroupBlock(cg)).toBe(true);
+        expect(isInputAreaBlock(cg)).toBe(false);
+        expect(isHintBlock(cg)).toBe(false);
+        expect(isCodeBlock(cg)).toBe(false);
+        expect(isMarkdownBlock(cg)).toBe(false);
+        expect(isMathDisplayBlock(cg)).toBe(false);
+        expect(isNewlineBlock(cg)).toBe(false);
+    });
+});
+
+// ============================================================
+// Rocq context tests (code_group serializes transparently)
+// ============================================================
+
+describe("code_group Rocq context", () => {
+    test("serializer serializes code_group transparently in Rocq config", () => {
+        const rocqConfig = configuration("coq");
+        const rocqSerializer = new DefaultTagSerializer(rocqConfig);
+
+        const innerBlocks = [
+            new MarkdownBlock("text", { from: 14, to: 18 }, { from: 14, to: 18 }, 0)
+        ];
+        const cg = new CodeGroupBlock(
+            "text", { from: 0, to: 23 }, { from: 14, to: 18 }, 0, innerBlocks
+        );
+        const doc = constructDocument([cg]);
+        const result = rocqSerializer.serializeDocument(doc);
+        expect(result).toBe("text");
+    });
+});
+
+// ============================================================
+// Command tests
+// ============================================================
+
+/**
+ * @jest-environment jsdom
+ */
+describe("wrapInCodeGroup command", () => {
+    function makeStateWithMarkdown(): EditorState {
+        const mdNode = WaterproofSchema.nodes.markdown.create({}, WaterproofSchema.text("hello"));
+        const doc = WaterproofSchema.nodes.doc.create({}, mdNode);
+        const state = EditorState.create({ doc });
+        // Select the markdown node
+        return state.apply(state.tr.setSelection(NodeSelection.create(state.doc, 0)));
+    }
+
+    test("wrapInCodeGroup wraps selected node in a code_group", () => {
+        const state = makeStateWithMarkdown();
+        let newState: EditorState | null = null;
+        const cmd = wrapInCodeGroup(config);
+        cmd(state, (tr) => { newState = state.apply(tr); });
+
+        expect(newState).not.toBeNull();
+        const doc = newState!.doc;
+        expect(doc.firstChild!.type.name).toBe("code_group");
+        expect(doc.firstChild!.firstChild!.type.name).toBe("markdown");
+    });
+
+    test("wrapInCodeGroup dry-run (no dispatch) returns true when node is selected", () => {
+        // Per ProseMirror convention, returning true without dispatch means "I can execute".
+        const state = makeStateWithMarkdown();
+        const cmd = wrapInCodeGroup(config);
+        const result = cmd(state, undefined);
+        expect(result).toBe(true);
+    });
+});
+
+describe("wpLift from code_group", () => {
+    test("wpLift lifts child out of code_group", () => {
+        const mdNode = WaterproofSchema.nodes.markdown.create({}, WaterproofSchema.text("hello"));
+        const cgNode = WaterproofSchema.nodes.code_group.create({}, mdNode);
+        const doc = WaterproofSchema.nodes.doc.create({}, cgNode);
+        // Select the code_group node
+        const state = EditorState.create({ doc });
+        const stateWithSel = state.apply(state.tr.setSelection(NodeSelection.create(state.doc, 0)));
+
+        let newState: EditorState | null = null;
+        const cmd = wpLift(config);
+        cmd(stateWithSel, (tr) => { newState = stateWithSel.apply(tr); });
+
+        expect(newState).not.toBeNull();
+        // After lifting, the markdown should be at doc level (no code_group wrapper)
+        expect(newState!.doc.firstChild!.type.name).toBe("markdown");
+    });
+});
+
+describe("checkInputArea with code_group nesting", () => {
+    test("returns true when selection is inside input nested in code_group", () => {
+        const mdNode = WaterproofSchema.nodes.markdown.create({}, WaterproofSchema.text("ans"));
+        const inputNode = WaterproofSchema.nodes.input.create({}, mdNode);
+        const cgNode = WaterproofSchema.nodes.code_group.create({}, inputNode);
+        const doc = WaterproofSchema.nodes.doc.create({}, cgNode);
+        const state = EditorState.create({ doc });
+        // Position 3 is inside the markdown text inside input inside code_group
+        const resolvedPos = doc.resolve(3);
+        const sel = state.tr.setSelection(
+            // Text selection inside the markdown node
+            state.tr.selection.constructor === NodeSelection
+                ? NodeSelection.create(doc, 0)
+                : state.tr.selection
+        ).selection;
+        // Manually test checkInputArea with the resolved position inside the input
+        // depth: doc(0) > code_group(1) > input(2) > markdown(3) > text
+        // from.node(1) = code_group, from.node(2) = input → should return true
+        const innerSel = { $from: doc.resolve(3) } as any;
+        expect(checkInputArea(innerSel)).toBe(true);
+    });
+
+    test("returns false when selection is in markdown directly inside code_group (no input)", () => {
+        const mdNode = WaterproofSchema.nodes.markdown.create({}, WaterproofSchema.text("ans"));
+        const cgNode = WaterproofSchema.nodes.code_group.create({}, mdNode);
+        const doc = WaterproofSchema.nodes.doc.create({}, cgNode);
+        // Position 2 is inside the markdown text directly inside code_group
+        const innerSel = { $from: doc.resolve(2) } as any;
+        expect(checkInputArea(innerSel)).toBe(false);
+    });
+});

--- a/__tests__/codegroup.test.ts
+++ b/__tests__/codegroup.test.ts
@@ -13,8 +13,8 @@ import { sanityCheckTree } from "./mapping/util";
 import { TagConfiguration } from "../src/api";
 import { wrapInContainer, wpLift } from "../src/commands";
 
-import { EditorState, NodeSelection } from "prosemirror-state";
-import { Fragment } from "prosemirror-model";
+import { EditorState, NodeSelection, Transaction } from "prosemirror-state";
+import { Fragment, Node as PNode } from "prosemirror-model";
 import { WaterproofSchema } from "../src/schema";
 import { checkInputArea } from "../src/commands/command-helpers";
 
@@ -34,6 +34,38 @@ const multileanSerializer = new DefaultTagSerializer(multileanConfig);
 function createTestMapping(blocks: WaterproofDocument) {
     const mapping = new Mapping(blocks, 1, config, serializer);
     return mapping.getMapping();
+}
+
+// ============================================================
+// Test utility helpers
+// ============================================================
+
+/** Constructs a document from blocks and serializes it with the given serializer (defaults to `serializer`). */
+function serializeBlocks(blocks: WaterproofDocument, ser = serializer): string {
+    return ser.serializeDocument(constructDocument(blocks));
+}
+
+/** Creates an EditorState with a NodeSelection at `pos`. */
+function stateWithNodeSelAt(doc: PNode, pos: number): EditorState {
+    const state = EditorState.create({ doc });
+    return state.apply(state.tr.setSelection(NodeSelection.create(state.doc, pos)));
+}
+
+/** Applies a ProseMirror command to `state`, returning the resulting state or null if not dispatched. */
+function applyCommand(
+    state: EditorState,
+    cmd: (s: EditorState, dispatch?: (tr: Transaction) => void) => boolean
+): EditorState | null {
+    let newState: EditorState | null = null;
+    cmd(state, (tr) => { newState = state.apply(tr); });
+    return newState;
+}
+
+/** Returns the type names of all direct children of a doc node. */
+function docChildTypes(doc: PNode): string[] {
+    const types: string[] = [];
+    doc.forEach(child => types.push(child.type.name));
+    return types;
 }
 
 // ============================================================
@@ -68,9 +100,7 @@ describe("container serialization", () => {
             { from: 0, to: 28 }, { from: 14, to: 23 }, 0,
             innerBlocks
         );
-        const doc = constructDocument([cg]);
-        const result = serializer.serializeDocument(doc);
-        expect(result).toBe("Some text");
+        expect(serializeBlocks([cg])).toBe("Some text");
     });
 
     test("serialize container with code block", () => {
@@ -82,9 +112,7 @@ describe("container serialization", () => {
             { from: 0, to: 42 }, { from: 14, to: 37 }, 0,
             innerBlocks
         );
-        const doc = constructDocument([cg]);
-        const result = serializer.serializeDocument(doc);
-        expect(result).toBe("```lean4\ndef x := 1\n```");
+        expect(serializeBlocks([cg])).toBe("```lean4\ndef x := 1\n```");
     });
 
     test("serialize container with input area", () => {
@@ -103,9 +131,7 @@ describe("container serialization", () => {
             { from: 0, to: 54 }, { from: 14, to: 49 }, 0,
             innerBlocks
         );
-        const doc = constructDocument([cg]);
-        const result = serializer.serializeDocument(doc);
-        expect(result).toBe("<input-area>input text</input-area>");
+        expect(serializeBlocks([cg])).toBe("<input-area>input text</input-area>");
     });
 
     test("serialize container with hint", () => {
@@ -125,9 +151,7 @@ describe("container serialization", () => {
             { from: 0, to: 61 }, { from: 14, to: 52 }, 0,
             innerBlocks
         );
-        const doc = constructDocument([cg]);
-        const result = serializer.serializeDocument(doc);
-        expect(result).toBe('<hint title="My Hint">hint text</hint>');
+        expect(serializeBlocks([cg])).toBe('<hint title="My Hint">hint text</hint>');
     });
 
     test("serialize container with math_display", () => {
@@ -139,9 +163,7 @@ describe("container serialization", () => {
             { from: 0, to: 26 }, { from: 14, to: 21 }, 0,
             innerBlocks
         );
-        const doc = constructDocument([cg]);
-        const result = serializer.serializeDocument(doc);
-        expect(result).toBe("$$x^2$$");
+        expect(serializeBlocks([cg])).toBe("$$x^2$$");
     });
 
     test("serialize container with non-empty tags (multilean)", () => {
@@ -153,9 +175,7 @@ describe("container serialization", () => {
             { from: 0, to: 31 }, { from: 14, to: 26 }, 0,
             innerBlocks
         );
-        const doc = constructDocument([cg]);
-        const result = multileanSerializer.serializeDocument(doc);
-        expect(result).toBe("::::multilean\nSome content\n::::");
+        expect(serializeBlocks([cg], multileanSerializer)).toBe("::::multilean\nSome content\n::::");
     });
 
     test("serialize container with multiple children", () => {
@@ -168,9 +188,7 @@ describe("container serialization", () => {
             { from: 0, to: 47 }, { from: 14, to: 42 }, 0,
             innerBlocks
         );
-        const doc = constructDocument([cg]);
-        const result = serializer.serializeDocument(doc);
-        expect(result).toBe("intro```lean4\ndef x := 1\n```");
+        expect(serializeBlocks([cg])).toBe("intro```lean4\ndef x := 1\n```");
     });
 });
 
@@ -336,9 +354,7 @@ describe("container Rocq context", () => {
         const cg = new ContainerBlock(
             "text", "test", { from: 0, to: 23 }, { from: 14, to: 18 }, 0, innerBlocks
         );
-        const doc = constructDocument([cg]);
-        const result = rocqSerializer.serializeDocument(doc);
-        expect(result).toBe("text");
+        expect(serializeBlocks([cg], rocqSerializer)).toBe("text");
     });
 });
 
@@ -353,16 +369,12 @@ describe("wrapInContainer command", () => {
     function makeStateWithMarkdown(): EditorState {
         const mdNode = WaterproofSchema.nodes.markdown.create({}, WaterproofSchema.text("hello"));
         const doc = WaterproofSchema.nodes.doc.create({}, mdNode);
-        const state = EditorState.create({ doc });
-        // Select the markdown node
-        return state.apply(state.tr.setSelection(NodeSelection.create(state.doc, 0)));
+        return stateWithNodeSelAt(doc, 0);
     }
 
     test("wrapInContainer wraps selected node in a container", () => {
         const state = makeStateWithMarkdown();
-        let newState: EditorState | null = null;
-        const cmd = wrapInContainer(config, "multilean");
-        cmd(state, (tr) => { newState = state.apply(tr); });
+        const newState = applyCommand(state, wrapInContainer(config, "multilean"));
 
         expect(newState).not.toBeNull();
         const doc = newState!.doc;
@@ -373,8 +385,7 @@ describe("wrapInContainer command", () => {
     test("wrapInContainer dry-run (no dispatch) returns true when node is selected", () => {
         // Per ProseMirror convention, returning true without dispatch means "I can execute".
         const state = makeStateWithMarkdown();
-        const cmd = wrapInContainer(config, "multilean");
-        const result = cmd(state, undefined);
+        const result = wrapInContainer(config, "multilean")(state, undefined);
         expect(result).toBe(true);
     });
 });
@@ -384,13 +395,9 @@ describe("wpLift from container", () => {
         const mdNode = WaterproofSchema.nodes.markdown.create({}, WaterproofSchema.text("hello"));
         const cgNode = WaterproofSchema.nodes.container.create({name: "test"}, mdNode);
         const doc = WaterproofSchema.nodes.doc.create({}, cgNode);
-        // Select the container node
-        const state = EditorState.create({ doc });
-        const stateWithSel = state.apply(state.tr.setSelection(NodeSelection.create(state.doc, 0)));
+        const stateWithSel = stateWithNodeSelAt(doc, 0);
 
-        let newState: EditorState | null = null;
-        const cmd = wpLift(config);
-        cmd(stateWithSel, (tr) => { newState = stateWithSel.apply(tr); });
+        const newState = applyCommand(stateWithSel, wpLift(config));
 
         expect(newState).not.toBeNull();
         // After lifting, the markdown should be at doc level (no container wrapper)
@@ -404,15 +411,6 @@ describe("checkInputArea with container nesting", () => {
         const inputNode = WaterproofSchema.nodes.input.create({}, mdNode);
         const cgNode = WaterproofSchema.nodes.container.create({name: "test"}, inputNode);
         const doc = WaterproofSchema.nodes.doc.create({}, cgNode);
-        const state = EditorState.create({ doc });
-        // Position 3 is inside the markdown text inside input inside container
-        const resolvedPos = doc.resolve(3);
-        const sel = state.tr.setSelection(
-            // Text selection inside the markdown node
-            state.tr.selection.constructor === NodeSelection
-                ? NodeSelection.create(doc, 0)
-                : state.tr.selection
-        ).selection;
         // Manually test checkInputArea with the resolved position inside the input
         // depth: doc(0) > container(1) > input(2) > markdown(3) > text
         // from.node(1) = container, from.node(2) = input → should return true
@@ -461,19 +459,15 @@ describe("wrapInContainer newline regression", () => {
         const nlNode = WaterproofSchema.nodes.newline.create();
         const codeNode = WaterproofSchema.nodes.code.create();
         const doc = WaterproofSchema.nodes.doc.create({}, Fragment.from([nlNode, codeNode]));
-        const state = EditorState.create({ doc });
-        const stateWithSel = state.apply(state.tr.setSelection(NodeSelection.create(state.doc, 1)));
+        const stateWithSel = stateWithNodeSelAt(doc, 1);
 
-        let newState: EditorState | null = null;
-        wrapInContainer(multileanConfig, "multilean")(stateWithSel, (tr) => { newState = stateWithSel.apply(tr); });
+        const newState = applyCommand(stateWithSel, wrapInContainer(multileanConfig, "multilean"));
         expect(newState).not.toBeNull();
 
-        const newDoc = newState!.doc;
         // Buggy behaviour: newline gets absorbed → doc.childCount=1, container contains [newline, code]
         // Fixed behaviour: doc.childCount=2, newline stays as first child
-        expect(newDoc.childCount).toBe(2);
-        expect(newDoc.child(0).type.name).toBe("newline");
-        expect(newDoc.child(1).type.name).toBe("container");
+        const newDoc = newState!.doc;
+        expect(docChildTypes(newDoc)).toEqual(["newline", "container"]);
         expect(newDoc.child(1).firstChild!.type.name).toBe("code");
     });
 });
@@ -484,8 +478,7 @@ describe("wrapInContainer container-in-container prevention", () => {
         const mdNode = WaterproofSchema.nodes.markdown.create({}, WaterproofSchema.text("hello"));
         const cgNode = WaterproofSchema.nodes.container.create({name: "inner"}, mdNode);
         const doc = WaterproofSchema.nodes.doc.create({}, cgNode);
-        const state = EditorState.create({ doc });
-        const stateWithSel = state.apply(state.tr.setSelection(NodeSelection.create(state.doc, 0)));
+        const stateWithSel = stateWithNodeSelAt(doc, 0);
         const result = wrapInContainer(multileanConfig, "multilean")(stateWithSel, undefined);
         expect(result).toBe(false);
     });
@@ -500,33 +493,22 @@ describe("wrapInContainer followed by content edit", () => {
         const codeNode = WaterproofSchema.nodes.code.create();
         const nl2Node = WaterproofSchema.nodes.newline.create();
         const doc = WaterproofSchema.nodes.doc.create({}, Fragment.from([nlNode, codeNode, nl2Node]));
-        const state = EditorState.create({ doc });
-        const stateWithSel = state.apply(state.tr.setSelection(NodeSelection.create(state.doc, 1)));
+        const stateWithSel = stateWithNodeSelAt(doc, 1);
 
-        let wrapped: EditorState | null = null;
-        wrapInContainer(multileanConfig, "multilean")(stateWithSel, (tr) => { wrapped = stateWithSel.apply(tr); });
+        const wrapped = applyCommand(stateWithSel, wrapInContainer(multileanConfig, "multilean"));
         expect(wrapped).not.toBeNull();
 
         // Verify structure after wrap: [newline, container[code], newline]
-        const wrappedDoc = wrapped!.doc;
-        expect(wrappedDoc.childCount).toBe(3);
-        expect(wrappedDoc.child(0).type.name).toBe("newline");
-        expect(wrappedDoc.child(1).type.name).toBe("container");
-        expect(wrappedDoc.child(1).firstChild!.type.name).toBe("code");
-        expect(wrappedDoc.child(2).type.name).toBe("newline");
+        expect(docChildTypes(wrapped!.doc)).toEqual(["newline", "container", "newline"]);
+        expect(wrapped!.doc.child(1).firstChild!.type.name).toBe("code");
 
         // Now insert text inside the code node (position 3: container open at 1,
         // code open at 2, code content starts at 3).
-        const editTr = wrapped!.tr.insertText("x", 3);
-        const edited = wrapped!.apply(editTr);
-        const editedDoc = edited.doc;
+        const edited = wrapped!.apply(wrapped!.tr.insertText("x", 3));
 
         // Structure must still be [newline, container[code_with_text], newline]
-        expect(editedDoc.childCount).toBe(3);
-        expect(editedDoc.child(0).type.name).toBe("newline");
-        expect(editedDoc.child(1).type.name).toBe("container");
-        expect(editedDoc.child(1).firstChild!.type.name).toBe("code");
-        expect(editedDoc.child(2).type.name).toBe("newline");
+        expect(docChildTypes(edited.doc)).toEqual(["newline", "container", "newline"]);
+        expect(edited.doc.child(1).firstChild!.type.name).toBe("code");
     });
 });
 
@@ -545,9 +527,8 @@ describe("wrapInContainer openRequiresNewline enforcement", () => {
         const mdNode = WaterproofSchema.nodes.markdown.create({});
         const codeNode = WaterproofSchema.nodes.code.create();
         const doc = WaterproofSchema.nodes.doc.create({}, Fragment.from([mdNode, codeNode]));
-        const state = EditorState.create({ doc });
         // markdown.nodeSize = 2 (empty atom), so code is at pos 2
-        const stateWithSel = state.apply(state.tr.setSelection(NodeSelection.create(state.doc, 2)));
+        const stateWithSel = stateWithNodeSelAt(doc, 2);
         const result = wrapInContainer(strictConfig, "multilean")(stateWithSel, undefined);
         expect(result).toBe(false);
     });
@@ -564,18 +545,13 @@ describe("wpLift with multiple children", () => {
             Fragment.from([mdNode, nlNode, codeNode])
         );
         const doc = WaterproofSchema.nodes.doc.create({}, cgNode);
-        const state = EditorState.create({ doc });
-        const stateWithSel = state.apply(state.tr.setSelection(NodeSelection.create(state.doc, 0)));
+        const stateWithSel = stateWithNodeSelAt(doc, 0);
 
-        let newState: EditorState | null = null;
-        wpLift(multileanConfig)(stateWithSel, (tr) => { newState = stateWithSel.apply(tr); });
+        const newState = applyCommand(stateWithSel, wpLift(multileanConfig));
         expect(newState).not.toBeNull();
 
         // Container is gone; children should be at doc level
-        const newDoc = newState!.doc;
-        expect(newDoc.firstChild!.type.name).toBe("markdown");
-        // All three inner nodes (markdown, newline, code) are now direct children of doc
-        const types = Array.from({ length: newDoc.childCount }, (_, i) => newDoc.child(i).type.name);
+        const types = docChildTypes(newState!.doc);
         expect(types).toContain("markdown");
         expect(types).toContain("newline");
         expect(types).toContain("code");

--- a/__tests__/codegroup.test.ts
+++ b/__tests__/codegroup.test.ts
@@ -361,7 +361,7 @@ describe("wrapInContainer command", () => {
     test("wrapInContainer wraps selected node in a container", () => {
         const state = makeStateWithMarkdown();
         let newState: EditorState | null = null;
-        const cmd = wrapInContainer(config);
+        const cmd = wrapInContainer(config, "multilean");
         cmd(state, (tr) => { newState = state.apply(tr); });
 
         expect(newState).not.toBeNull();
@@ -373,7 +373,7 @@ describe("wrapInContainer command", () => {
     test("wrapInContainer dry-run (no dispatch) returns true when node is selected", () => {
         // Per ProseMirror convention, returning true without dispatch means "I can execute".
         const state = makeStateWithMarkdown();
-        const cmd = wrapInContainer(config);
+        const cmd = wrapInContainer(config, "multilean");
         const result = cmd(state, undefined);
         expect(result).toBe(true);
     });
@@ -465,7 +465,7 @@ describe("wrapInContainer newline regression", () => {
         const stateWithSel = state.apply(state.tr.setSelection(NodeSelection.create(state.doc, 1)));
 
         let newState: EditorState | null = null;
-        wrapInContainer(multileanConfig)(stateWithSel, (tr) => { newState = stateWithSel.apply(tr); });
+        wrapInContainer(multileanConfig, "multilean")(stateWithSel, (tr) => { newState = stateWithSel.apply(tr); });
         expect(newState).not.toBeNull();
 
         const newDoc = newState!.doc;
@@ -486,7 +486,7 @@ describe("wrapInContainer container-in-container prevention", () => {
         const doc = WaterproofSchema.nodes.doc.create({}, cgNode);
         const state = EditorState.create({ doc });
         const stateWithSel = state.apply(state.tr.setSelection(NodeSelection.create(state.doc, 0)));
-        const result = wrapInContainer(multileanConfig)(stateWithSel, undefined);
+        const result = wrapInContainer(multileanConfig, "multilean")(stateWithSel, undefined);
         expect(result).toBe(false);
     });
 });
@@ -504,7 +504,7 @@ describe("wrapInContainer followed by content edit", () => {
         const stateWithSel = state.apply(state.tr.setSelection(NodeSelection.create(state.doc, 1)));
 
         let wrapped: EditorState | null = null;
-        wrapInContainer(multileanConfig)(stateWithSel, (tr) => { wrapped = stateWithSel.apply(tr); });
+        wrapInContainer(multileanConfig, "multilean")(stateWithSel, (tr) => { wrapped = stateWithSel.apply(tr); });
         expect(wrapped).not.toBeNull();
 
         // Verify structure after wrap: [newline, container[code], newline]
@@ -548,7 +548,7 @@ describe("wrapInContainer openRequiresNewline enforcement", () => {
         const state = EditorState.create({ doc });
         // markdown.nodeSize = 2 (empty atom), so code is at pos 2
         const stateWithSel = state.apply(state.tr.setSelection(NodeSelection.create(state.doc, 2)));
-        const result = wrapInContainer(strictConfig)(stateWithSel, undefined);
+        const result = wrapInContainer(strictConfig, "multilean")(stateWithSel, undefined);
         expect(result).toBe(false);
     });
 });

--- a/__tests__/commands/all-insertions.test.ts
+++ b/__tests__/commands/all-insertions.test.ts
@@ -34,8 +34,9 @@ const tagConf: TagConfiguration = {
         openTag: "$$", closeTag: "$$",
         openRequiresNewline: false, closeRequiresNewline: false
     },
-    codeGroup: {
-        openTag: "::::multilean\n", closeTag: "\n::::",
+    container: {
+        openTag: (name: string) => `::::${name}\n`,
+        closeTag: (_name: string) => "\n::::",
         openRequiresNewline: false, closeRequiresNewline: false,
     }
 }

--- a/__tests__/commands/all-insertions.test.ts
+++ b/__tests__/commands/all-insertions.test.ts
@@ -9,6 +9,7 @@ import { configuration } from "../../src/markdown-defaults";
 import { EditorView } from "prosemirror-view";
 import { WaterproofSchema } from "../../src/schema";
 
+/* Note that this is not a real tag configuration, the multilean is exclusive to lean files */
 const tagConf: TagConfiguration = {
     markdown: {
         openTag: "", closeTag: "",
@@ -32,6 +33,10 @@ const tagConf: TagConfiguration = {
     math: {
         openTag: "$$", closeTag: "$$",
         openRequiresNewline: false, closeRequiresNewline: false
+    },
+    codeGroup: {
+        openTag: "::::multilean\n", closeTag: "\n::::",
+        openRequiresNewline: false, closeRequiresNewline: false,
     }
 }
 
@@ -42,7 +47,7 @@ const initialStateMath = {"doc":{"type":"doc","content":[{"type":"math_display",
 const startingCell: Array<[string, any]> = [
     ["Latex", initialStateMath],
     ["Markdown", initialStateMD],
-    ["Code", initialStateCode]
+    ["Code", initialStateCode],
 ];
 
 const insertableTypes: Array<[string, (place: InsertionPlace, conf: TagConfiguration) => Command, string]> = [

--- a/__tests__/commands/insert-commands.test.ts
+++ b/__tests__/commands/insert-commands.test.ts
@@ -5,7 +5,7 @@
 import { EditorState, TextSelection } from "prosemirror-state";
 import { EditorView } from "prosemirror-view";
 import { WaterproofSchema } from "../../src/schema";
-import { getCmdInsertCode } from "../../src/commands/insert-command";
+import { getCmdInsertCode, getCmdInsertMarkdown } from "../../src/commands/insert-command";
 import { InsertionPlace } from "../../src/commands";
 import { configuration } from "../../src/markdown-defaults";
 
@@ -18,6 +18,29 @@ jest.mock('../../src/inputArea.ts', () => ({
     getState: jest.fn(() => ({ teacher: true }))
   }
 }));
+
+// A doc with a single code cell; selection inside the code content (position 11 = after 9 chars).
+const stateOneCode = {"doc":{"type":"doc","content":[{"type":"code","content":[{"type":"text","text":"Goal True."}]}]},"selection":{"type":"text","anchor":11,"head":11}};
+
+test("Insert markdown below code cell adds a newline separator", () => {
+    const view = new EditorView(null, {state: EditorState.fromJSON({schema: WaterproofSchema}, stateOneCode)});
+
+    const cmd = getCmdInsertMarkdown(InsertionPlace.Below, tagConf);
+    const res = cmd(view.state, view.dispatch, view);
+
+    expect(res).toBe(true);
+
+    // The newline node between code and markdown is required so that the serializer
+    // does not place markdown text on the same line as the closing code fence ("\n```").
+    const expected = {"doc":{"type":"doc",
+        "content":[
+            {"type":"code","content":[{"type":"text","text":"Goal True."}]},
+            {"type":"newline"},
+            {"type":"markdown"}
+        ]},
+        "selection":{"type":"text","anchor":11,"head":11}};
+    expect(view.state.toJSON()).toStrictEqual(expected);
+});
 
 test("Insert code below twice (selection static)", () => {
     const view = new EditorView(null, {state: EditorState.fromJSON({schema: WaterproofSchema}, state)});

--- a/__tests__/commands/insert-commands.test.ts
+++ b/__tests__/commands/insert-commands.test.ts
@@ -42,6 +42,29 @@ test("Insert markdown below code cell adds a newline separator", () => {
     expect(view.state.toJSON()).toStrictEqual(expected);
 });
 
+// A doc with a single code cell; selection inside the code content.
+const stateOneCodeForAbove = {"doc":{"type":"doc","content":[{"type":"code","content":[{"type":"text","text":"Goal True."}]}]},"selection":{"type":"text","anchor":11,"head":11}};
+
+test("Insert markdown above code cell adds a newline separator", () => {
+    const view = new EditorView(null, {state: EditorState.fromJSON({schema: WaterproofSchema}, stateOneCodeForAbove)});
+
+    const cmd = getCmdInsertMarkdown(InsertionPlace.Above, tagConf);
+    const res = cmd(view.state, view.dispatch, view);
+
+    expect(res).toBe(true);
+
+    // The newline node between markdown and code is required so that the serializer
+    // does not place markdown text on the same line as the opening code fence ("```lean\n").
+    const expected = {"doc":{"type":"doc",
+        "content":[
+            {"type":"markdown"},
+            {"type":"newline"},
+            {"type":"code","content":[{"type":"text","text":"Goal True."}]}
+        ]},
+        "selection":{"type":"text","anchor":14,"head":14}};
+    expect(view.state.toJSON()).toStrictEqual(expected);
+});
+
 test("Insert code below twice (selection static)", () => {
     const view = new EditorView(null, {state: EditorState.fromJSON({schema: WaterproofSchema}, state)});
 

--- a/__tests__/commands/wrap-commands.test.ts
+++ b/__tests__/commands/wrap-commands.test.ts
@@ -1,0 +1,288 @@
+import { EditorState, NodeSelection } from "prosemirror-state";
+import { Fragment } from "prosemirror-model";
+import { WaterproofSchema } from "../../src/schema";
+import { wrapInInput, wrapInHint } from "../../src/commands";
+import { DefaultTagSerializer } from "../../src/serialization/DocumentSerializer";
+import { TagConfiguration } from "../../src/api";
+
+// Lean-like tag configuration: input, hint, and code all require surrounding newlines.
+const leanConfig: TagConfiguration = {
+    code:     { openTag: "```lean\n",                          closeTag: "\n```",  openRequiresNewline: true,  closeRequiresNewline: true  },
+    hint:     { openTag: (t: string) => `:::hint "${t}"\n`,   closeTag: "\n:::",  openRequiresNewline: true,  closeRequiresNewline: true  },
+    input:    { openTag: ":::input\n",                         closeTag: "\n:::",  openRequiresNewline: true,  closeRequiresNewline: true  },
+    markdown: { openTag: "",                                   closeTag: "",       openRequiresNewline: false, closeRequiresNewline: false },
+    math:     { openTag: "$$`",                                closeTag: "`",      openRequiresNewline: false, closeRequiresNewline: false },
+    container:{ openTag: (n: string) => `::::${n}\n`,         closeTag: () => "\n::::", openRequiresNewline: true, closeRequiresNewline: true },
+};
+const leanSerializer = new DefaultTagSerializer(leanConfig);
+
+/** Build a doc from an array of nodes and select the node at the given index. */
+function makeStateWithSelection(nodes: import("prosemirror-model").Node[], selectedIndex: number): EditorState {
+    const doc = WaterproofSchema.nodes.doc.create({}, Fragment.from(nodes));
+    const pos = nodes.slice(0, selectedIndex).reduce((acc, n) => acc + n.nodeSize, 0);
+    const state = EditorState.create({ doc });
+    return state.apply(state.tr.setSelection(NodeSelection.create(state.doc, pos)));
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+const nl       = () => WaterproofSchema.nodes.newline.create();
+const code     = (text = "") => text
+    ? WaterproofSchema.nodes.code.create({}, WaterproofSchema.text(text))
+    : WaterproofSchema.nodes.code.create();
+const markdown = (text = "") => text
+    ? WaterproofSchema.nodes.markdown.create({}, WaterproofSchema.text(text))
+    : WaterproofSchema.nodes.markdown.create();
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Dry-run correctness (no dispatch)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("wrapInInput dry-run with Lean config", () => {
+    test("returns true even without a preceding newline (will be inserted on dispatch)", () => {
+        const state = makeStateWithSelection([code()], 0);
+        expect(wrapInInput(leanConfig)(state, undefined)).toBe(true);
+    });
+
+    test("returns true even without a following newline (will be inserted on dispatch)", () => {
+        const state = makeStateWithSelection([nl(), code()], 1);
+        expect(wrapInInput(leanConfig)(state, undefined)).toBe(true);
+    });
+
+    test("returns true when both surrounding newlines are already present", () => {
+        const state = makeStateWithSelection([nl(), code(), nl()], 1);
+        expect(wrapInInput(leanConfig)(state, undefined)).toBe(true);
+    });
+
+    test("returns true for markdown node without preceding newline", () => {
+        const state = makeStateWithSelection([markdown()], 0);
+        expect(wrapInInput(leanConfig)(state, undefined)).toBe(true);
+    });
+});
+
+describe("wrapInHint dry-run with Lean config", () => {
+    test("returns true even without a preceding newline", () => {
+        const state = makeStateWithSelection([code()], 0);
+        expect(wrapInHint(leanConfig)(state, undefined)).toBe(true);
+    });
+
+    test("returns true when both surrounding newlines are present", () => {
+        const state = makeStateWithSelection([nl(), code(), nl()], 1);
+        expect(wrapInHint(leanConfig)(state, undefined)).toBe(true);
+    });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Document structure after wrapping
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("wrapInInput document structure (Lean config)", () => {
+    test("surrounding newlines stay OUTSIDE the input, not inside", () => {
+        // Doc: [nl, code, nl]  ← the code is surrounded by the required newlines
+        const state = makeStateWithSelection([nl(), code(), nl()], 1);
+
+        let newState: EditorState | null = null;
+        wrapInInput(leanConfig)(state, (tr) => { newState = state.apply(tr); });
+
+        expect(newState).not.toBeNull();
+        const doc = newState!.doc;
+
+        // Expected: [nl, input([code]), nl]  — 3 top-level children
+        // Buggy:    [input([nl, code, nl])]  — 1 top-level child (whole doc swallowed)
+        expect(doc.childCount).toBe(3);
+        expect(doc.child(0).type.name).toBe("newline");
+        expect(doc.child(1).type.name).toBe("input");
+        expect(doc.child(2).type.name).toBe("newline");
+
+        const inputNode = doc.child(1);
+        // The input must contain exactly the code node — no extra newline wrappers.
+        expect(inputNode.childCount).toBe(1);
+        expect(inputNode.child(0).type.name).toBe("code");
+    });
+
+    test("wrapping a code cell inside a larger document leaves neighbours intact", () => {
+        // Doc: [code("a"), nl, code("b"), nl, code("c")]
+        // Select code("b") and wrap in input.
+        const state = makeStateWithSelection(
+            [code("a"), nl(), code("b"), nl(), code("c")],
+            2  // index 2 = code("b")
+        );
+
+        let newState: EditorState | null = null;
+        wrapInInput(leanConfig)(state, (tr) => { newState = state.apply(tr); });
+
+        expect(newState).not.toBeNull();
+        const doc = newState!.doc;
+
+        // Expected: [code("a"), nl, input([code("b")]), nl, code("c")]
+        expect(doc.childCount).toBe(5);
+        expect(doc.child(0).type.name).toBe("code");
+        expect(doc.child(1).type.name).toBe("newline");
+        expect(doc.child(2).type.name).toBe("input");
+        expect(doc.child(3).type.name).toBe("newline");
+        expect(doc.child(4).type.name).toBe("code");
+
+        expect(doc.child(2).childCount).toBe(1);
+        expect(doc.child(2).child(0).type.name).toBe("code");
+    });
+});
+
+describe("wrapInHint document structure (Lean config)", () => {
+    test("surrounding newlines stay OUTSIDE the hint, not inside", () => {
+        const state = makeStateWithSelection([nl(), code(), nl()], 1);
+
+        let newState: EditorState | null = null;
+        wrapInHint(leanConfig)(state, (tr) => { newState = state.apply(tr); });
+
+        expect(newState).not.toBeNull();
+        const doc = newState!.doc;
+
+        expect(doc.childCount).toBe(3);
+        expect(doc.child(0).type.name).toBe("newline");
+        expect(doc.child(1).type.name).toBe("hint");
+        expect(doc.child(2).type.name).toBe("newline");
+
+        const hintNode = doc.child(1);
+        expect(hintNode.childCount).toBe(1);
+        expect(hintNode.child(0).type.name).toBe("code");
+    });
+
+    test("hint node receives default title attribute", () => {
+        const state = makeStateWithSelection([nl(), code(), nl()], 1);
+
+        let newState: EditorState | null = null;
+        wrapInHint(leanConfig)(state, (tr) => { newState = state.apply(tr); });
+
+        const hintNode = newState!.doc.child(1);
+        expect(hintNode.attrs.title).toBe("💡 Hint");
+    });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Serialization round-trip
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("wrapInInput serialization (Lean config)", () => {
+    test("serialized output has no double-newline inside :::input block", () => {
+        // Doc: [code("a"), nl, code("b"), nl, code("c")]  — wrap code("b")
+        const state = makeStateWithSelection(
+            [code("a"), nl(), code("b"), nl(), code("c")],
+            2
+        );
+
+        let newState: EditorState | null = null;
+        wrapInInput(leanConfig)(state, (tr) => { newState = state.apply(tr); });
+
+        const result = leanSerializer.serializeDocument(newState!.doc);
+
+        // Correct: single \n at the boundary between :::input and the code fence
+        expect(result).toBe(
+            "```lean\na\n```\n:::input\n```lean\nb\n```\n:::\n```lean\nc\n```"
+        );
+        // The buggy output would be:
+        // "```lean\na\n```\n:::input\n\n```lean\nb\n```\n\n:::\n```lean\nc\n```"
+        expect(result).not.toContain(":::input\n\n");
+        expect(result).not.toContain("\n\n:::");
+    });
+});
+
+describe("wrapInHint serialization (Lean config)", () => {
+    test("serialized output has no double-newline inside :::hint block", () => {
+        const state = makeStateWithSelection(
+            [code("a"), nl(), code("b"), nl(), code("c")],
+            2
+        );
+
+        let newState: EditorState | null = null;
+        wrapInHint(leanConfig)(state, (tr) => { newState = state.apply(tr); });
+
+        const result = leanSerializer.serializeDocument(newState!.doc);
+
+        expect(result).toBe(
+            `\`\`\`lean\na\n\`\`\`\n:::hint "💡 Hint"\n\`\`\`lean\nb\n\`\`\`\n:::\n\`\`\`lean\nc\n\`\`\``
+        );
+        expect(result).not.toContain(':::hint "💡 Hint"\n\n');
+        expect(result).not.toContain("\n\n:::");
+    });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Wrapping markdown nodes (the broken case in Lean documents)
+//
+// In a Lean document the tokenizer does not preserve the newline that follows
+// a code-close fence (``\n``` ``) as a NewlineBlock — it is non-significant and
+// gets absorbed into the following markdown text.  Therefore a markdown node
+// that follows a code block has NO preceding NewlineBlock.  The previous
+// implementation rejected the wrap because input/hint require a preceding
+// newline; the correct behaviour is to insert the missing newline(s) instead.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("wrapInInput on markdown after code (no preceding newline)", () => {
+    test("dry-run returns true even without a preceding newline", () => {
+        // Typical Lean structure: code followed immediately by markdown, no NewlineBlock.
+        const state = makeStateWithSelection([code("x"), markdown("hello")], 1);
+        // Currently returns false — the command incorrectly rejects instead of inserting
+        // the required newline.
+        expect(wrapInInput(leanConfig)(state, undefined)).toBe(true);
+    });
+
+    test("inserts a newline before the input when none was present", () => {
+        const state = makeStateWithSelection([code("x"), markdown("hello")], 1);
+
+        let newState: EditorState | null = null;
+        wrapInInput(leanConfig)(state, (tr) => { newState = state.apply(tr); });
+
+        expect(newState).not.toBeNull();
+        const doc = newState!.doc;
+
+        // Expected: [code, newline, input([markdown])]
+        // (No trailing newline needed: nothing follows the input)
+        expect(doc.childCount).toBe(3);
+        expect(doc.child(0).type.name).toBe("code");
+        expect(doc.child(1).type.name).toBe("newline");
+        expect(doc.child(2).type.name).toBe("input");
+        expect(doc.child(2).childCount).toBe(1);
+        expect(doc.child(2).child(0).type.name).toBe("markdown");
+    });
+
+    test("serializes correctly — no double-newline, valid Lean syntax", () => {
+        // Doc: [code("a"), markdown("text"), newline, code("b")]
+        // markdown has no preceding newline (Lean document pattern).
+        const state = makeStateWithSelection(
+            [code("a"), markdown("text"), nl(), code("b")],
+            1  // select the markdown
+        );
+
+        let newState: EditorState | null = null;
+        wrapInInput(leanConfig)(state, (tr) => { newState = state.apply(tr); });
+
+        const result = leanSerializer.serializeDocument(newState!.doc);
+
+        // The missing newline before :::input must be added; the existing newline
+        // after the input (before code("b")) must be preserved.
+        expect(result).toBe("```lean\na\n```\n:::input\ntext\n:::\n```lean\nb\n```");
+    });
+});
+
+describe("wrapInHint on markdown after code (no preceding newline)", () => {
+    test("dry-run returns true even without a preceding newline", () => {
+        const state = makeStateWithSelection([code("x"), markdown("hello")], 1);
+        expect(wrapInHint(leanConfig)(state, undefined)).toBe(true);
+    });
+
+    test("inserts a newline before the hint when none was present", () => {
+        const state = makeStateWithSelection([code("x"), markdown("hello")], 1);
+
+        let newState: EditorState | null = null;
+        wrapInHint(leanConfig)(state, (tr) => { newState = state.apply(tr); });
+
+        expect(newState).not.toBeNull();
+        const doc = newState!.doc;
+
+        expect(doc.childCount).toBe(3);
+        expect(doc.child(0).type.name).toBe("code");
+        expect(doc.child(1).type.name).toBe("newline");
+        expect(doc.child(2).type.name).toBe("hint");
+        expect(doc.child(2).childCount).toBe(1);
+        expect(doc.child(2).child(0).type.name).toBe("markdown");
+    });
+});

--- a/__tests__/container.test.ts
+++ b/__tests__/container.test.ts
@@ -445,7 +445,7 @@ describe("checkInputArea with container nesting", () => {
 });
 
 // ============================================================
-// Regression tests for feature/codegroup bugs
+// Regression tests for container bugs
 // ============================================================
 
 // T1 — Regression: wrapInContainer must not absorb the preceding newline.

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -1,4 +1,5 @@
 import { HighlightStyle, LanguageSupport } from "@codemirror/language";
+import { EditorState } from "prosemirror-state";
 import { Block } from "../document";
 import { DocumentSerializer } from "../serialization/DocumentSerializer";
 import { WaterproofCompletion, WaterproofSymbol } from "./Completions";
@@ -106,6 +107,8 @@ export type MenuBarEntry = {
     hoverText: string;
     /** The function to execute when the button is clicked */
     callback: () => void;
+    /** Optional predicate called with the current editor state to determine if the button should be active (enabled). When omitted the button is always active. */
+    isActive?: (state: EditorState) => boolean;
     /** Control the visibility of the entry */
     buttonVisibility?: {
         /** When set to true the entry will only be visible in teacher mode */

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -84,7 +84,7 @@ export type TagConfiguration = {
     hint:  { openTag: ((title: string) => string), closeTag: string } & RequiresNewline,
     input: OpenCloseTag & RequiresNewline,
     math: OpenCloseTag & RequiresNewline,
-    codeGroup: OpenCloseTag & RequiresNewline,
+    container: { openTag: (name: string) => string, closeTag: (name: string) => string } & RequiresNewline,
 }
 
 export class NodeUpdateError extends Error {

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -84,6 +84,7 @@ export type TagConfiguration = {
     hint:  { openTag: ((title: string) => string), closeTag: string } & RequiresNewline,
     input: OpenCloseTag & RequiresNewline,
     math: OpenCloseTag & RequiresNewline,
+    codeGroup: OpenCloseTag & RequiresNewline,
 }
 
 export class NodeUpdateError extends Error {

--- a/src/commands/command-helpers.ts
+++ b/src/commands/command-helpers.ts
@@ -156,8 +156,9 @@ export function allowedToInsert(state: EditorState): boolean {
 export function checkInputArea(sel: Selection): boolean {
     const from = sel.$from;
     const depth = from.depth;
-    // An input area can only ever have depth = 1, since it is a 
-    // top level node (see WaterproofSchema in `schema.ts`)
+    // An input area can be at depth = 1 (top level) or depth = 2 (inside a code_group)
     if (depth < 1) return false;
-    return from.node(1).type === WaterproofSchema.nodes.input;
+    if (from.node(1).type === WaterproofSchema.nodes.input) return true;
+    if (depth >= 2 && from.node(1).type === WaterproofSchema.nodes.code_group && from.node(2).type === WaterproofSchema.nodes.input) return true;
+    return false;
 }

--- a/src/commands/command-helpers.ts
+++ b/src/commands/command-helpers.ts
@@ -6,7 +6,7 @@ import { INPUT_AREA_PLUGIN_KEY } from "../inputArea";
 import { WaterproofSchema } from "../schema";
 import { newline } from "../document/blocks/schema";
 import { TagConfiguration } from "../api";
-import { getParentAndIndex, needsNewlineAfter } from "./utils";
+import { getParentAndIndex, needsNewlineAfter, needsNewlineBefore } from "./utils";
 
 /////// Helper functions /////////
 
@@ -17,9 +17,12 @@ import { getParentAndIndex, needsNewlineAfter } from "./utils";
  * @param nodeType The type of node to insert (one of `WaterproofSchema.nodes`)
  * @returns An insertion transaction.
  */
-export function insertAbove(state: EditorState, tr: Transaction, nodeType: NodeType, insertNewlineBeforeIfNotExists: boolean, insertNewlineAfterIfNotExists: boolean): Transaction | undefined {
+export function insertAbove(state: EditorState, tr: Transaction, nodeType: NodeType, tagConf: TagConfiguration): Transaction | undefined {
     const sel = state.selection;
     let trans: Transaction = tr;
+
+    const insertNewlineBeforeIfNotExists = needsNewlineBefore(nodeType, tagConf);
+    const insertNewlineAfterIfNotExists  = needsNewlineAfter(nodeType, tagConf);
 
     const parentAndIndex = getParentAndIndex(sel);
     if (parentAndIndex === null) return;
@@ -49,13 +52,17 @@ export function insertAbove(state: EditorState, tr: Transaction, nodeType: NodeT
     const beforeNewline = parent.maybeChild(index - 2);
     const hasNewlineBefore = beforeNewline === null ? false : beforeNewline.type === WaterproofSchema.nodes.newline;
 
+    // A newline is also required after the new node if the current node (now below) requires one before its open tag.
+    const currentNode = parent.maybeChild(index);
+    const currentNeedsNewlineBefore = tagConf && currentNode ? needsNewlineBefore(currentNode.type, tagConf) : false;
+
     const toInsert: PNode[] = [];
 
     if (insertNewlineBeforeIfNotExists && !hasNewlineBefore && beforeIsNewline) {
         toInsert.push(newline());
     }
     toInsert.push(nodeType.create());
-    if (insertNewlineAfterIfNotExists && !beforeIsNewline) {
+    if ((insertNewlineAfterIfNotExists || currentNeedsNewlineBefore) && !beforeIsNewline) {
         toInsert.push(newline());
     }
 
@@ -71,9 +78,12 @@ export function insertAbove(state: EditorState, tr: Transaction, nodeType: NodeT
  * @param nodeType The type of node to insert (one of `WaterproofSchema.nodes`)
  * @returns An insertion transaction.
  */
-export function insertBelow(state: EditorState, tr: Transaction, nodeType: NodeType, insertNewlineBeforeIfNotExists: boolean, insertNewlineAfterIfNotExists: boolean, tagConf?: TagConfiguration): Transaction | undefined {
+export function insertBelow(state: EditorState, tr: Transaction, nodeType: NodeType, tagConf: TagConfiguration): Transaction | undefined {
     const sel = state.selection;
     let trans: Transaction = tr;
+
+    const insertNewlineBeforeIfNotExists = needsNewlineBefore(nodeType, tagConf);
+    const insertNewlineAfterIfNotExists  = needsNewlineAfter(nodeType, tagConf);
 
     const parentAndIndex = getParentAndIndex(sel);
     if (parentAndIndex === null) return;

--- a/src/commands/command-helpers.ts
+++ b/src/commands/command-helpers.ts
@@ -156,9 +156,9 @@ export function allowedToInsert(state: EditorState): boolean {
 export function checkInputArea(sel: Selection): boolean {
     const from = sel.$from;
     const depth = from.depth;
-    // An input area can be at depth = 1 (top level) or depth = 2 (inside a code_group)
+    // An input area can be at depth = 1 (top level) or depth = 2 (inside a container)
     if (depth < 1) return false;
     if (from.node(1).type === WaterproofSchema.nodes.input) return true;
-    if (depth >= 2 && from.node(1).type === WaterproofSchema.nodes.code_group && from.node(2).type === WaterproofSchema.nodes.input) return true;
+    if (depth >= 2 && from.node(1).type === WaterproofSchema.nodes.container && from.node(2).type === WaterproofSchema.nodes.input) return true;
     return false;
 }

--- a/src/commands/command-helpers.ts
+++ b/src/commands/command-helpers.ts
@@ -5,7 +5,8 @@ import { EditorState, TextSelection, Transaction, Selection, NodeSelection } fro
 import { INPUT_AREA_PLUGIN_KEY } from "../inputArea";
 import { WaterproofSchema } from "../schema";
 import { newline } from "../document/blocks/schema";
-import { getParentAndIndex } from "./utils";
+import { TagConfiguration } from "../api";
+import { getParentAndIndex, needsNewlineAfter } from "./utils";
 
 /////// Helper functions /////////
 
@@ -16,7 +17,7 @@ import { getParentAndIndex } from "./utils";
  * @param nodeType The type of node to insert (one of `WaterproofSchema.nodes`)
  * @returns An insertion transaction.
  */
-export function insertAbove(state: EditorState, tr: Transaction, nodeType: NodeType, insertNewlineBeforeIfNotExists: boolean, insertNewlineAfterIfNotExists: boolean): Transaction | undefined {    
+export function insertAbove(state: EditorState, tr: Transaction, nodeType: NodeType, insertNewlineBeforeIfNotExists: boolean, insertNewlineAfterIfNotExists: boolean): Transaction | undefined {
     const sel = state.selection;
     let trans: Transaction = tr;
 
@@ -33,7 +34,7 @@ export function insertAbove(state: EditorState, tr: Transaction, nodeType: NodeT
         // To and from point directly to beginning and end of node.
         pos = sel.from;
     } else if (sel instanceof TextSelection) {
-        // TODO: This -1 is here to make sure that we do not insert 3 random code cells. 
+        // TODO: This -1 is here to make sure that we do not insert 3 random code cells.
         // I can't fully wrap my head around why it is needed at the moment though.
         pos = sel.from - sel.$from.parentOffset - 1;
     } else {
@@ -70,10 +71,10 @@ export function insertAbove(state: EditorState, tr: Transaction, nodeType: NodeT
  * @param nodeType The type of node to insert (one of `WaterproofSchema.nodes`)
  * @returns An insertion transaction.
  */
-export function insertBelow(state: EditorState, tr: Transaction, nodeType: NodeType, insertNewlineBeforeIfNotExists: boolean, insertNewlineAfterIfNotExists: boolean): Transaction | undefined {
+export function insertBelow(state: EditorState, tr: Transaction, nodeType: NodeType, insertNewlineBeforeIfNotExists: boolean, insertNewlineAfterIfNotExists: boolean, tagConf?: TagConfiguration): Transaction | undefined {
     const sel = state.selection;
     let trans: Transaction = tr;
-    
+
     const parentAndIndex = getParentAndIndex(sel);
     if (parentAndIndex === null) return;
     const {parent, index} = parentAndIndex;
@@ -82,7 +83,7 @@ export function insertBelow(state: EditorState, tr: Transaction, nodeType: NodeT
     const afterIsNewline = nodeBelowSelection === null ? false : (nodeBelowSelection.type === WaterproofSchema.nodes.newline);
 
     let pos;
-    
+
     if (sel instanceof NodeSelection) {
         // To and from point directly to beginning and end of node.
         pos = sel.to;
@@ -96,13 +97,16 @@ export function insertBelow(state: EditorState, tr: Transaction, nodeType: NodeT
         // Assumption: If a newline appears after a node the current node wants that.
         pos += 1; // We are going to insert after
     }
-    
+
     const afterNewline = parent.maybeChild(index + 2);
     const hasNewlineAfter = afterNewline === null ? false : afterNewline.type === WaterproofSchema.nodes.newline;
 
-    
+    // A newline is also required before the new node if the current node's close tag requires one.
+    const currentNode = parent.maybeChild(index);
+    const currentNeedsNewlineAfter = tagConf && currentNode ? needsNewlineAfter(currentNode.type, tagConf) : false;
+
     const toInsert: PNode[] = [];
-    if (insertNewlineBeforeIfNotExists && !afterIsNewline) {
+    if ((insertNewlineBeforeIfNotExists || currentNeedsNewlineAfter) && !afterIsNewline) {
         toInsert.push(newline());
     }
     toInsert.push(nodeType.create());

--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -1,8 +1,7 @@
-import { Fragment, NodeType } from "prosemirror-model";
+import { NodeRange, NodeType } from "prosemirror-model";
 import { Command, EditorState, NodeSelection, TextSelection, Transaction } from "prosemirror-state";
 import { EditorView } from "prosemirror-view";
-import { liftTarget, ReplaceAroundStep } from "prosemirror-transform";
-import { Slice } from "prosemirror-model";
+import { liftTarget } from "prosemirror-transform";
 import { WaterproofSchema } from "../schema";
 import { getParentAndIndex, needsNewlineAfter, needsNewlineBefore } from "./utils";
 import { TagConfiguration } from "../api";
@@ -153,17 +152,12 @@ export function wrapInContainer(tagConf: TagConfiguration, name: string): Comman
 
         if (needsNewlineBefore(WaterproofSchema.nodes.container, tagConf) && !beforeIsNewline) return false;
 
-        const blockRange = sel.$from.blockRange(sel.$to);
-        if (blockRange === null) return false;
-
         if (dispatch) {
             const tr = state.tr;
-            // Use ReplaceAroundStep directly: for a top-level NodeSelection,
-            // blockRange computes range.start = -1 (boundary position math),
-            // which causes tr.wrap to include the preceding newline inside the container.
-            const containerNode = WaterproofSchema.nodes.container.create({name});
-            const slice = new Slice(Fragment.from(containerNode), 0, 0);
-            tr.step(new ReplaceAroundStep(sel.from, sel.to, sel.from, sel.to, slice, 1, true));
+            // Construct the NodeRange directly from the selection endpoints rather than using
+            // sel.$from.blockRange(sel.$to), which at the top level computes range.start = sel.from - 1
+            // and would pull the preceding newline inside the container.
+            tr.wrap(new NodeRange(sel.$from, sel.$to, sel.$from.depth), [{type: WaterproofSchema.nodes.container, attrs: {name}}]);
             tr.setSelection(NodeSelection.create(tr.doc, tr.mapping.map(sel.from)));
             tr.scrollIntoView();
             dispatch(tr);
@@ -190,12 +184,7 @@ function wpWrapIn(nodeType: NodeType, tagConf: TagConfiguration): Command {
 
         if (dispatch) {
             const tr = state.tr;
-            // Use ReplaceAroundStep directly, mirroring wrapInContainer.
-            // tr.wrap(blockRange, …) computes a top-level blockRange with start=-1,
-            // which causes it to absorb the preceding newline into the wrapper.
-            const wrapperNode = nodeType.create();
-            const slice = new Slice(Fragment.from(wrapperNode), 0, 0);
-            tr.step(new ReplaceAroundStep(sel.from, sel.to, sel.from, sel.to, slice, 1, true));
+            tr.wrap(new NodeRange(sel.$from, sel.$to, sel.$from.depth), [{type: nodeType}]);
 
             // Insert any missing newlines.  After ReplaceAroundStep the wrapper
             // occupies [sel.from, sel.to + 2] (one extra token on each side).

--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -17,8 +17,8 @@ export function wpLift(_tagConf: TagConfiguration): Command {
         const after = $to.nodeAfter;
         
         const {type} = node;
-        if (type !== WaterproofSchema.nodes.hint && type !== WaterproofSchema.nodes.input && type !== WaterproofSchema.nodes.code_group) {
-            // We can only lift hint, input area, or code_group nodes.
+        if (type !== WaterproofSchema.nodes.hint && type !== WaterproofSchema.nodes.input && type !== WaterproofSchema.nodes.container) {
+            // We can only lift hint, input area, or container nodes.
             return false;
         }
 
@@ -139,8 +139,8 @@ export function wrapInInput(tagConf: TagConfiguration): Command {
     return wpWrapIn(WaterproofSchema.nodes.input, tagConf);
 }
 
-export function wrapInCodeGroup(tagConf: TagConfiguration): Command {
-    return wpWrapIn(WaterproofSchema.nodes.code_group, tagConf);
+export function wrapInContainer(tagConf: TagConfiguration): Command {
+    return wpWrapIn(WaterproofSchema.nodes.container, tagConf);
 }
 
 function wpWrapIn(nodeType: NodeType, tagConf: TagConfiguration): Command {

--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -178,63 +178,42 @@ function wpWrapIn(nodeType: NodeType, tagConf: TagConfiguration): Command {
     return (state, dispatch) => {
         const sel = state.selection;
         if (!(sel instanceof NodeSelection)) return false;
-        
+
         const before = sel.$from.nodeBefore;
         const after = sel.$to.nodeAfter;
-        
+        const beforeIsNewline = before !== null && before.type === WaterproofSchema.nodes.newline;
+        const afterIsNewline  = after  !== null && after.type  === WaterproofSchema.nodes.newline;
+
+        // If the wrapper requires a surrounding newline that is not already present,
+        // we insert one rather than rejecting.  This handles the common Lean pattern
+        // where markdown directly follows a code block with no intervening NewlineBlock.
+        const addNewlineBefore = needsNewlineBefore(nodeType, tagConf) && !beforeIsNewline && before !== null;
+        const addNewlineAfter  = needsNewlineAfter(nodeType, tagConf)  && !afterIsNewline  && after  !== null;
+
         if (dispatch) {
-            const beforeIsNewline = before === null ? false : before.type === WaterproofSchema.nodes.newline;
-            const afterIsNewline = after === null ? false : after.type === WaterproofSchema.nodes.newline;
-            const nodeBeingWrapped = sel.node;
-            const needsBefore = needsNewlineBefore(nodeBeingWrapped.type, tagConf);
-            const needsAfter = needsNewlineAfter(nodeBeingWrapped.type, tagConf);
-            
-            if ((needsBefore && !beforeIsNewline) || (needsAfter && !afterIsNewline)) {
-                return false;
-            }
-            
-            let $start = sel.$from;
-            let $end = sel.$to;
-            const consumeBefore = needsBefore && beforeIsNewline;
-            const consumeAfter = needsAfter && afterIsNewline;
-            // console.log("Consume before and after:", consumeBefore, consumeAfter);
-            if (before !== null && consumeBefore) {
-                // extend the selection to incldue the before newline node
-                $start = state.doc.resolve(sel.from - before.nodeSize);
-            }
-            if (after !== null && consumeAfter) {
-                // extend the selection to include the after newline node
-                $end = state.doc.resolve(sel.to + after.nodeSize);
-            }
-            
-            // We extend the blockRange to include the newlines if they are being consumed.
-            const blockRange = $start.blockRange($end);
-            if (blockRange === null) return false;
             const tr = state.tr;
-            tr.wrap(blockRange, [{type: nodeType}]);
+            // Use ReplaceAroundStep directly, mirroring wrapInContainer.
+            // tr.wrap(blockRange, …) computes a top-level blockRange with start=-1,
+            // which causes it to absorb the preceding newline into the wrapper.
+            const wrapperNode = nodeType.create();
+            const slice = new Slice(Fragment.from(wrapperNode), 0, 0);
+            tr.step(new ReplaceAroundStep(sel.from, sel.to, sel.from, sel.to, slice, 1, true));
 
-            // We potentially have to insert newlines before or after the newly created input area.
-            if (consumeBefore) {
-                const nodeBeforeNewline = $start.nodeBefore;
-                if (nodeBeforeNewline !== null && needsNewlineAfter(nodeBeforeNewline.type, tagConf)) {
-                    // Inserting newline before the input area
-                    tr.insert(tr.mapping.map(blockRange.start) - 1, WaterproofSchema.nodes.newline.create());
-                }
+            // Insert any missing newlines.  After ReplaceAroundStep the wrapper
+            // occupies [sel.from, sel.to + 2] (one extra token on each side).
+            // Insert the after-newline first (higher position) so that the
+            // before-insert position is not shifted.
+            if (addNewlineAfter) {
+                tr.insert(sel.to + 2, WaterproofSchema.nodes.newline.create());
             }
-            
-            if (consumeAfter) {
-                const nodeAfterNewline = $end.nodeAfter;
-                if (nodeAfterNewline !== null && needsNewlineBefore(nodeAfterNewline.type, tagConf)) {
-                    // Inserting newline after the input area
-                    tr.insert(tr.mapping.map(blockRange.end), WaterproofSchema.nodes.newline.create());
-                }
+            if (addNewlineBefore) {
+                tr.insert(sel.from, WaterproofSchema.nodes.newline.create());
             }
 
-            // Finally, dispatch the transaction and set the selection to be the node selection of the newly created input area.
-            tr.setSelection(NodeSelection.create(tr.doc, tr.mapping.map(sel.from)));
+            // The wrapper node is at sel.from + (1 if we inserted a newline before it).
+            tr.setSelection(NodeSelection.create(tr.doc, sel.from + (addNewlineBefore ? 1 : 0)));
             tr.scrollIntoView();
             dispatch(tr);
-            return true;
         }
         return true;
     }

--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -1,7 +1,8 @@
-import { NodeType } from "prosemirror-model";
+import { Fragment, NodeType } from "prosemirror-model";
 import { Command, EditorState, NodeSelection, TextSelection, Transaction } from "prosemirror-state";
 import { EditorView } from "prosemirror-view";
-import { liftTarget } from "prosemirror-transform";
+import { liftTarget, ReplaceAroundStep } from "prosemirror-transform";
+import { Slice } from "prosemirror-model";
 import { WaterproofSchema } from "../schema";
 import { getParentAndIndex, needsNewlineAfter, needsNewlineBefore } from "./utils";
 import { TagConfiguration } from "../api";
@@ -139,8 +140,38 @@ export function wrapInInput(tagConf: TagConfiguration): Command {
     return wpWrapIn(WaterproofSchema.nodes.input, tagConf);
 }
 
-export function wrapInContainer(tagConf: TagConfiguration): Command {
-    return wpWrapIn(WaterproofSchema.nodes.container, tagConf);
+export function wrapInContainer(tagConf: TagConfiguration, name: string = "multilean"): Command {
+    return (state, dispatch) => {
+        const sel = state.selection;
+        if (!(sel instanceof NodeSelection)) return false;
+
+        // Don't wrap a container inside another container
+        if (sel.node.type === WaterproofSchema.nodes.container) return false;
+
+        const before = sel.$from.nodeBefore;
+        const after = sel.$to.nodeAfter;
+        const beforeIsNewline = before?.type === WaterproofSchema.nodes.newline;
+        const afterIsNewline = after?.type === WaterproofSchema.nodes.newline;
+
+        if (needsNewlineBefore(WaterproofSchema.nodes.container, tagConf) && !beforeIsNewline) return false;
+
+        const blockRange = sel.$from.blockRange(sel.$to);
+        if (blockRange === null) return false;
+
+        if (dispatch) {
+            const tr = state.tr;
+            // Use ReplaceAroundStep directly: for a top-level NodeSelection,
+            // blockRange computes range.start = -1 (boundary position math),
+            // which causes tr.wrap to include the preceding newline inside the container.
+            const containerNode = WaterproofSchema.nodes.container.create({name});
+            const slice = new Slice(Fragment.from(containerNode), 0, 0);
+            tr.step(new ReplaceAroundStep(sel.from, sel.to, sel.from, sel.to, slice, 1, true));
+            tr.setSelection(NodeSelection.create(tr.doc, tr.mapping.map(sel.from)));
+            tr.scrollIntoView();
+            dispatch(tr);
+        }
+        return true;
+    };
 }
 
 function wpWrapIn(nodeType: NodeType, tagConf: TagConfiguration): Command {

--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -17,8 +17,8 @@ export function wpLift(_tagConf: TagConfiguration): Command {
         const after = $to.nodeAfter;
         
         const {type} = node;
-        if (type !== WaterproofSchema.nodes.hint && type !== WaterproofSchema.nodes.input) {
-            // We can only lift hint or input area nodes.
+        if (type !== WaterproofSchema.nodes.hint && type !== WaterproofSchema.nodes.input && type !== WaterproofSchema.nodes.code_group) {
+            // We can only lift hint, input area, or code_group nodes.
             return false;
         }
 
@@ -137,6 +137,10 @@ export function wrapInHint(tagConf: TagConfiguration): Command {
 
 export function wrapInInput(tagConf: TagConfiguration): Command {
     return wpWrapIn(WaterproofSchema.nodes.input, tagConf);
+}
+
+export function wrapInCodeGroup(tagConf: TagConfiguration): Command {
+    return wpWrapIn(WaterproofSchema.nodes.code_group, tagConf);
 }
 
 function wpWrapIn(nodeType: NodeType, tagConf: TagConfiguration): Command {

--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -140,7 +140,7 @@ export function wrapInInput(tagConf: TagConfiguration): Command {
     return wpWrapIn(WaterproofSchema.nodes.input, tagConf);
 }
 
-export function wrapInContainer(tagConf: TagConfiguration, name: string = "multilean"): Command {
+export function wrapInContainer(tagConf: TagConfiguration, name: string): Command {
     return (state, dispatch) => {
         const sel = state.selection;
         if (!(sel instanceof NodeSelection)) return false;
@@ -149,9 +149,7 @@ export function wrapInContainer(tagConf: TagConfiguration, name: string = "multi
         if (sel.node.type === WaterproofSchema.nodes.container) return false;
 
         const before = sel.$from.nodeBefore;
-        const after = sel.$to.nodeAfter;
         const beforeIsNewline = before?.type === WaterproofSchema.nodes.newline;
-        const afterIsNewline = after?.type === WaterproofSchema.nodes.newline;
 
         if (needsNewlineBefore(WaterproofSchema.nodes.container, tagConf) && !beforeIsNewline) return false;
 

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,3 +1,3 @@
 // Export all insertion commands for use in the menubar or with keybindings.
-export { wpLift, wrapInHint, wrapInInput, deleteSelection } from "./commands";
+export { wpLift, wrapInHint, wrapInInput, wrapInCodeGroup, deleteSelection } from "./commands";
 export { InsertionPlace } from "./types";

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,3 +1,3 @@
 // Export all insertion commands for use in the menubar or with keybindings.
-export { wpLift, wrapInHint, wrapInInput, wrapInCodeGroup, deleteSelection } from "./commands";
+export { wpLift, wrapInHint, wrapInInput, wrapInContainer, deleteSelection } from "./commands";
 export { InsertionPlace } from "./types";

--- a/src/commands/insert-command.ts
+++ b/src/commands/insert-command.ts
@@ -16,7 +16,7 @@ export function getCmdInsertMarkdown(place: InsertionPlace, tagConf: TagConfigur
 
         const f = place === InsertionPlace.Above ? insertAbove : insertBelow;
 
-        const trans = f(state, state.tr, WaterproofSchema.nodes.markdown, tagConf.markdown.openRequiresNewline, tagConf.markdown.closeRequiresNewline);
+        const trans = f(state, state.tr, WaterproofSchema.nodes.markdown, tagConf.markdown.openRequiresNewline, tagConf.markdown.closeRequiresNewline, tagConf);
 
         if (trans === undefined) { return false; }
         
@@ -34,7 +34,7 @@ export function getCmdInsertLatex(place: InsertionPlace, tagConf: TagConfigurati
         if (!allowedToInsert(state)) return false;
         
         const f = place  === InsertionPlace.Above ? insertAbove : insertBelow; 
-        const trans = f(state, state.tr, WaterproofSchema.nodes.math_display, tagConf.math.openRequiresNewline, tagConf.math.closeRequiresNewline);
+        const trans = f(state, state.tr, WaterproofSchema.nodes.math_display, tagConf.math.openRequiresNewline, tagConf.math.closeRequiresNewline, tagConf);
 
         if (trans === undefined) { return false; }
         
@@ -52,7 +52,7 @@ export function getCmdInsertCode(place: InsertionPlace, tagConf: TagConfiguratio
         if (!allowedToInsert(state)) return false;
         
         const f = place === InsertionPlace.Above ? insertAbove : insertBelow;
-        const trans = f(state, state.tr, WaterproofSchema.nodes.code, tagConf.code.openRequiresNewline, tagConf.code.closeRequiresNewline);
+        const trans = f(state, state.tr, WaterproofSchema.nodes.code, tagConf.code.openRequiresNewline, tagConf.code.closeRequiresNewline, tagConf);
 
         if (trans === undefined) { return false; }
         

--- a/src/commands/insert-command.ts
+++ b/src/commands/insert-command.ts
@@ -16,7 +16,7 @@ export function getCmdInsertMarkdown(place: InsertionPlace, tagConf: TagConfigur
 
         const f = place === InsertionPlace.Above ? insertAbove : insertBelow;
 
-        const trans = f(state, state.tr, WaterproofSchema.nodes.markdown, tagConf.markdown.openRequiresNewline, tagConf.markdown.closeRequiresNewline, tagConf);
+        const trans = f(state, state.tr, WaterproofSchema.nodes.markdown, tagConf);
 
         if (trans === undefined) { return false; }
         
@@ -34,7 +34,7 @@ export function getCmdInsertLatex(place: InsertionPlace, tagConf: TagConfigurati
         if (!allowedToInsert(state)) return false;
         
         const f = place  === InsertionPlace.Above ? insertAbove : insertBelow; 
-        const trans = f(state, state.tr, WaterproofSchema.nodes.math_display, tagConf.math.openRequiresNewline, tagConf.math.closeRequiresNewline, tagConf);
+        const trans = f(state, state.tr, WaterproofSchema.nodes.math_display, tagConf);
 
         if (trans === undefined) { return false; }
         
@@ -52,7 +52,7 @@ export function getCmdInsertCode(place: InsertionPlace, tagConf: TagConfiguratio
         if (!allowedToInsert(state)) return false;
         
         const f = place === InsertionPlace.Above ? insertAbove : insertBelow;
-        const trans = f(state, state.tr, WaterproofSchema.nodes.code, tagConf.code.openRequiresNewline, tagConf.code.closeRequiresNewline, tagConf);
+        const trans = f(state, state.tr, WaterproofSchema.nodes.code, tagConf);
 
         if (trans === undefined) { return false; }
         

--- a/src/commands/utils.ts
+++ b/src/commands/utils.ts
@@ -38,8 +38,8 @@ export function needsNewlineBefore(nodeType: NodeType, tagConf: TagConfiguration
             return tagConf.markdown.openRequiresNewline;
         case WaterproofSchema.nodes.math_display:
             return tagConf.math.openRequiresNewline;
-        case WaterproofSchema.nodes.code_group:
-            return tagConf.codeGroup.openRequiresNewline;
+        case WaterproofSchema.nodes.container:
+            return tagConf.container.openRequiresNewline;
         default:
             return false;
     }
@@ -57,8 +57,8 @@ export function needsNewlineAfter(nodeType: NodeType, tagConf: TagConfiguration)
             return tagConf.markdown.closeRequiresNewline;
         case WaterproofSchema.nodes.math_display:
             return tagConf.math.closeRequiresNewline;
-        case WaterproofSchema.nodes.code_group:
-            return tagConf.codeGroup.closeRequiresNewline;
+        case WaterproofSchema.nodes.container:
+            return tagConf.container.closeRequiresNewline;
         default:
             return false;
     }

--- a/src/commands/utils.ts
+++ b/src/commands/utils.ts
@@ -38,6 +38,8 @@ export function needsNewlineBefore(nodeType: NodeType, tagConf: TagConfiguration
             return tagConf.markdown.openRequiresNewline;
         case WaterproofSchema.nodes.math_display:
             return tagConf.math.openRequiresNewline;
+        case WaterproofSchema.nodes.code_group:
+            return tagConf.codeGroup.openRequiresNewline;
         default:
             return false;
     }
@@ -55,6 +57,8 @@ export function needsNewlineAfter(nodeType: NodeType, tagConf: TagConfiguration)
             return tagConf.markdown.closeRequiresNewline;
         case WaterproofSchema.nodes.math_display:
             return tagConf.math.closeRequiresNewline;
+        case WaterproofSchema.nodes.code_group:
+            return tagConf.codeGroup.closeRequiresNewline;
         default:
             return false;
     }

--- a/src/document/blocks/block.ts
+++ b/src/document/blocks/block.ts
@@ -8,7 +8,7 @@ export enum BLOCK_NAME {
     MARKDOWN = "markdown",
     CODE = "code",
     NEWLINE = "newline",
-    CODE_GROUP = "code_group",
+    CONTAINER = "container",
 }
 
 export interface BlockRange {
@@ -27,7 +27,7 @@ export interface Block {
     /** The linenumber (0 based) at the start of this block */
     lineStart: number;
 
-    /** Blocks that are children of this block, only valid for InputArea, Hint, and CodeGroup Blocks. */
+    /** Blocks that are children of this block, only valid for InputArea, Hint, and Container Blocks. */
     innerBlocks?: Block[];
 
     /** Convert this block to the corresponding ProseMirror node. */

--- a/src/document/blocks/block.ts
+++ b/src/document/blocks/block.ts
@@ -8,6 +8,7 @@ export enum BLOCK_NAME {
     MARKDOWN = "markdown",
     CODE = "code",
     NEWLINE = "newline",
+    CODE_GROUP = "code_group",
 }
 
 export interface BlockRange {
@@ -26,7 +27,7 @@ export interface Block {
     /** The linenumber (0 based) at the start of this block */
     lineStart: number;
 
-    /** Blocks that are children of this block, only valid for InputArea and Hint Blocks. */
+    /** Blocks that are children of this block, only valid for InputArea, Hint, and CodeGroup Blocks. */
     innerBlocks?: Block[];
 
     /** Convert this block to the corresponding ProseMirror node. */

--- a/src/document/blocks/blocktypes.ts
+++ b/src/document/blocks/blocktypes.ts
@@ -1,7 +1,7 @@
 import { Node } from "prosemirror-model";
 import { WaterproofSchema } from "../../schema";
 import { BLOCK_NAME, Block, BlockRange } from "./block";
-import { code, hint, inputArea, markdown, mathDisplay, newline } from "./schema";
+import { code, codeGroup, hint, inputArea, markdown, mathDisplay, newline } from "./schema";
 
 const indentation = (level: number): string => "  ".repeat(level);
 const debugInfo = (block: Block): string => `{range=${block.range.from}-${block.range.to}}`;
@@ -167,5 +167,40 @@ export class NewlineBlock implements Block {
     // Debug print function.
     debugPrint(level: number): void {
         console.log(`${indentation(level)}Newline`);
+    }
+}
+
+/**
+ * CodeGroupBlocks are container blocks that group multiple blocks together.
+ * In Lean context, they are delimited by ::::multilean and ::::.
+ * They can contain both top-level blocks (input, hint) and leaf blocks (math, code, markdown).
+ */
+export class CodeGroupBlock implements Block {
+    public type = BLOCK_NAME.CODE_GROUP;
+    public innerBlocks: Block[];
+
+    constructor(
+        public stringContent: string,
+        public range: BlockRange,
+        public innerRange: BlockRange,
+        public lineStart: number,
+        childBlocks: Block[] | ((innerContent: string, innerRange: BlockRange, lineStartOffset: number) => Block[])
+    ) {
+        if (typeof childBlocks === "function") {
+            this.innerBlocks = childBlocks(stringContent, innerRange, lineStart);
+        } else {
+            this.innerBlocks = childBlocks;
+        }
+    }
+
+    toProseMirror() {
+        const childNodes = this.innerBlocks.map(block => block.toProseMirror());
+        return codeGroup(childNodes);
+    }
+
+    debugPrint(level: number): void {
+        console.log(`${indentation(level)}CodeGroupBlock {${debugInfo(this)}} [`);
+        this.innerBlocks.forEach(block => block.debugPrint(level + 1));
+        console.log(`${indentation(level)}]`);
     }
 }

--- a/src/document/blocks/blocktypes.ts
+++ b/src/document/blocks/blocktypes.ts
@@ -1,7 +1,7 @@
 import { Node } from "prosemirror-model";
 import { WaterproofSchema } from "../../schema";
 import { BLOCK_NAME, Block, BlockRange } from "./block";
-import { code, codeGroup, hint, inputArea, markdown, mathDisplay, newline } from "./schema";
+import { code, container, hint, inputArea, markdown, mathDisplay, newline } from "./schema";
 
 const indentation = (level: number): string => "  ".repeat(level);
 const debugInfo = (block: Block): string => `{range=${block.range.from}-${block.range.to}}`;
@@ -171,16 +171,18 @@ export class NewlineBlock implements Block {
 }
 
 /**
- * CodeGroupBlocks are container blocks that group multiple blocks together.
- * In Lean context, they are delimited by ::::multilean and ::::.
+ * ContainerBlocks are generic container blocks that group multiple blocks together.
+ * They carry a name to identify the container type.
+ * In Lean context, multilean blocks are represented as containers with name "multilean".
  * They can contain both top-level blocks (input, hint) and leaf blocks (math, code, markdown).
  */
-export class CodeGroupBlock implements Block {
-    public type = BLOCK_NAME.CODE_GROUP;
+export class ContainerBlock implements Block {
+    public type = BLOCK_NAME.CONTAINER;
     public innerBlocks: Block[];
 
     constructor(
         public stringContent: string,
+        public name: string,
         public range: BlockRange,
         public innerRange: BlockRange,
         public lineStart: number,
@@ -195,11 +197,11 @@ export class CodeGroupBlock implements Block {
 
     toProseMirror() {
         const childNodes = this.innerBlocks.map(block => block.toProseMirror());
-        return codeGroup(childNodes);
+        return container(this.name, childNodes);
     }
 
     debugPrint(level: number): void {
-        console.log(`${indentation(level)}CodeGroupBlock {${debugInfo(this)}} [`);
+        console.log(`${indentation(level)}ContainerBlock(${this.name}) {${debugInfo(this)}} [`);
         this.innerBlocks.forEach(block => block.debugPrint(level + 1));
         console.log(`${indentation(level)}]`);
     }

--- a/src/document/blocks/schema.ts
+++ b/src/document/blocks/schema.ts
@@ -36,9 +36,9 @@ export const hint = (title: string, childNodes: ProseNode[]): ProseNode => {
     return WaterproofSchema.nodes.hint.create({title}, childNodes);
 }
 
-/** Construct code group prosemirror node. */
-export const codeGroup = (childNodes: ProseNode[]): ProseNode => {
-    return WaterproofSchema.nodes.code_group.create({}, childNodes);
+/** Construct container prosemirror node. */
+export const container = (name: string, childNodes: ProseNode[]): ProseNode => {
+    return WaterproofSchema.nodes.container.create({name}, childNodes);
 }
 
 // ##### Special newline block ######

--- a/src/document/blocks/schema.ts
+++ b/src/document/blocks/schema.ts
@@ -36,6 +36,11 @@ export const hint = (title: string, childNodes: ProseNode[]): ProseNode => {
     return WaterproofSchema.nodes.hint.create({title}, childNodes);
 }
 
+/** Construct code group prosemirror node. */
+export const codeGroup = (childNodes: ProseNode[]): ProseNode => {
+    return WaterproofSchema.nodes.code_group.create({}, childNodes);
+}
+
 // ##### Special newline block ######
 export const newline = () => {
     return WaterproofSchema.nodes.newline.create();

--- a/src/document/blocks/typeguards.ts
+++ b/src/document/blocks/typeguards.ts
@@ -1,5 +1,5 @@
 import { BLOCK_NAME, Block } from "./block";
-import { CodeBlock, CodeGroupBlock, HintBlock, InputAreaBlock, MarkdownBlock, MathDisplayBlock, NewlineBlock } from "./blocktypes";
+import { CodeBlock, ContainerBlock, HintBlock, InputAreaBlock, MarkdownBlock, MathDisplayBlock, NewlineBlock } from "./blocktypes";
 
 export const isInputAreaBlock = (block: Block): block is InputAreaBlock => block.type === BLOCK_NAME.INPUT_AREA;
 export const isHintBlock = (block: Block): block is HintBlock => block.type === BLOCK_NAME.HINT;
@@ -7,4 +7,4 @@ export const isMathDisplayBlock = (block: Block): block is MathDisplayBlock => b
 export const isCodeBlock = (block: Block): block is CodeBlock => block.type === BLOCK_NAME.CODE;
 export const isMarkdownBlock = (block: Block): block is MarkdownBlock => block.type === BLOCK_NAME.MARKDOWN;
 export const isNewlineBlock = (block: Block): block is NewlineBlock => block.type === BLOCK_NAME.NEWLINE;
-export const isCodeGroupBlock = (block: Block): block is CodeGroupBlock => block.type === BLOCK_NAME.CODE_GROUP;
+export const isContainerBlock = (block: Block): block is ContainerBlock => block.type === BLOCK_NAME.CONTAINER;

--- a/src/document/blocks/typeguards.ts
+++ b/src/document/blocks/typeguards.ts
@@ -1,9 +1,10 @@
 import { BLOCK_NAME, Block } from "./block";
-import { CodeBlock, HintBlock, InputAreaBlock, MarkdownBlock, MathDisplayBlock, NewlineBlock } from "./blocktypes";
+import { CodeBlock, CodeGroupBlock, HintBlock, InputAreaBlock, MarkdownBlock, MathDisplayBlock, NewlineBlock } from "./blocktypes";
 
 export const isInputAreaBlock = (block: Block): block is InputAreaBlock => block.type === BLOCK_NAME.INPUT_AREA;
 export const isHintBlock = (block: Block): block is HintBlock => block.type === BLOCK_NAME.HINT;
 export const isMathDisplayBlock = (block: Block): block is MathDisplayBlock => block.type === BLOCK_NAME.MATH_DISPLAY;
 export const isCodeBlock = (block: Block): block is CodeBlock => block.type === BLOCK_NAME.CODE;
 export const isMarkdownBlock = (block: Block): block is MarkdownBlock => block.type === BLOCK_NAME.MARKDOWN;
-export const isNewlineBlock = (block: Block): block is NewlineBlock => block.type === BLOCK_NAME.NEWLINE; 
+export const isNewlineBlock = (block: Block): block is NewlineBlock => block.type === BLOCK_NAME.NEWLINE;
+export const isCodeGroupBlock = (block: Block): block is CodeGroupBlock => block.type === BLOCK_NAME.CODE_GROUP;

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -2,7 +2,7 @@ import { mathPlugin, mathSerializer } from "@benrbray/prosemirror-math";
 import { selectParentNode } from "prosemirror-commands";
 import { keymap } from "prosemirror-keymap";
 import { Node as ProseNode } from "prosemirror-model";
-import { EditorState, NodeSelection, Plugin, Selection, TextSelection, Transaction } from "prosemirror-state";
+import { Command, EditorState, NodeSelection, Plugin, Selection, TextSelection, Transaction } from "prosemirror-state";
 import { ReplaceAroundStep, ReplaceStep, Step } from "prosemirror-transform";
 import { EditorView } from "prosemirror-view";
 import { undo, redo, history } from "prosemirror-history";
@@ -756,6 +756,14 @@ export class WaterproofEditor {
 				severity: d.severity
 			}
 		});
+	}
+
+	/**
+	 * Execute a ProseMirror command on the editor.
+	 * @param cmd The ProseMirror command to execute.
+	 */
+	public executeProsemirrorCommand(cmd: Command): void {
+		if (this._view) cmd(this._view.state, this._view.dispatch, this._view);
 	}
 
 	// Editor API

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,3 +9,4 @@ export * as "markdown" from "./markdown-defaults";
 export { DocumentSerializer, DefaultTagSerializer } from "./serialization/DocumentSerializer";
 export { Node } from "prosemirror-model";
 export * from "./edit-utils";
+export { wrapInContainer } from "./commands";

--- a/src/mapping/mapping.ts
+++ b/src/mapping/mapping.ts
@@ -155,7 +155,9 @@ export class Mapping {
         function buildSubtree(blocks: Block[]): TreeNode[] {
             return blocks.map(block => {
 
-                const title = typeguards.isHintBlock(block) ? block.title : "";
+                const title = typeguards.isHintBlock(block) ? block.title
+                    : typeguards.isContainerBlock(block) ? block.name
+                    : "";
 
                 const node = new TreeNode(
                     block.type,

--- a/src/mapping/nodeUpdate.ts
+++ b/src/mapping/nodeUpdate.ts
@@ -24,6 +24,8 @@ export class NodeUpdate {
                 return [this.tagConf.input.openTag, this.tagConf.input.closeTag];
             case "math_display":
                 return [this.tagConf.math.openTag, this.tagConf.math.closeTag];
+            case "container":
+                return [this.tagConf.container.openTag(title), this.tagConf.container.closeTag(title)];
             default:
                 throw new NodeUpdateError(`Unsupported node type: ${nodeName}`);
         }
@@ -186,13 +188,14 @@ export class NodeUpdate {
             )
         }
 
-        const [openTagForNode, closeTagForNode] = this.nodeNameToTagPair(node.type.name, node.attrs.title ? node.attrs.title : "");
+        const nodeTitle = node.attrs.title ? node.attrs.title : (node.attrs.name ? node.attrs.name : "");
+        const [openTagForNode, closeTagForNode] = this.nodeNameToTagPair(node.type.name, nodeTitle);
 
         const treeNode = new TreeNode(
             node.type.name, // node type
             {from: startOrig + openTagForNode.length, to: 0}, // inner range
             {from: startOrig, to: 0}, // full range
-            node.attrs.title ? node.attrs.title : "", // title
+            nodeTitle, // title
             startProse + 1, 0, // prosemirror start, end
             {from: startProse, to: 0},
             0
@@ -367,24 +370,38 @@ export class NodeUpdate {
             throw new NodeUpdateError(" We only support ReplaceAroundSteps with a single wrapping node ");
         }
 
-        // Check that the wrapping node is of a supported type (hint or input)
+        // Check that the wrapping node is of a supported type (hint, input, or container)
         const insertedNodeType = wrappingNode.type.name;
-        if (insertedNodeType !== "hint" && insertedNodeType !== "input") {
-            throw new NodeUpdateError(" We only support wrapping in hints or inputs ");
+        if (insertedNodeType !== "hint" && insertedNodeType !== "input" && insertedNodeType !== "container") {
+            throw new NodeUpdateError(" We only support wrapping in hints, inputs, or containers ");
         }
 
-        // If we are wrapping in a hint node we need to have a title attribute
-        const title: string = insertedNodeType === "hint" ? wrappingNode.attrs.title : "";
+        // If we are wrapping in a hint node we need to have a title attribute; container uses name attribute
+        const title: string = insertedNodeType === "hint" ? wrappingNode.attrs.title
+            : insertedNodeType === "container" ? wrappingNode.attrs.name
+            : "";
         // Get the tags for the wrapping node
         const [openTag, closeTag] = this.nodeNameToTagPair(insertedNodeType, title);
 
         // The step includes a range of nodes that are wrapped. We use the mapping
         // to find the node at gapFrom (the first one being wrapped) and the node
         // at gapTo (the last one being wrapped).
-        const nodesBeingWrappedStart = tree.findNodeByProsePos(step.gapFrom);
+        let nodesBeingWrappedStart = tree.findNodeByProsePos(step.gapFrom);
         const nodesBeingWrappedEnd = tree.findNodeByProsePos(step.gapTo);
         // If one of the two doesn't exist we error
         if (!nodesBeingWrappedStart || !nodesBeingWrappedEnd) throw new NodeUpdateError(" Could not find node in mapping ");
+
+        // findNodeByProsePos is biased: at a boundary position it returns the node ENDING there.
+        // If gapFrom equals nodesBeingWrappedStart.pmRange.to, we got the preceding node instead
+        // of the node that starts at gapFrom. Advance to the next sibling to correct this.
+        if (nodesBeingWrappedStart.pmRange.to === step.gapFrom) {
+            const parent = tree.findParent(nodesBeingWrappedStart);
+            const siblings = parent ? parent.children : tree.root.children;
+            const idx = siblings.indexOf(nodesBeingWrappedStart);
+            if (idx + 1 < siblings.length) {
+                nodesBeingWrappedStart = siblings[idx + 1];
+            }
+        }
 
         // Generate the document change (this is a wrapping document change)
         const docChange: WrappingDocChange = {

--- a/src/markdown-defaults/index.ts
+++ b/src/markdown-defaults/index.ts
@@ -28,6 +28,10 @@ export function configuration(languageId: string): TagConfiguration {
         math: {
             openTag: "$$", closeTag: "$$",
             openRequiresNewline: false, closeRequiresNewline: false
+        },
+        codeGroup: {
+            openTag: "", closeTag: "",
+            openRequiresNewline: false, closeRequiresNewline: false
         }
     }
 };

--- a/src/markdown-defaults/index.ts
+++ b/src/markdown-defaults/index.ts
@@ -29,8 +29,9 @@ export function configuration(languageId: string): TagConfiguration {
             openTag: "$$", closeTag: "$$",
             openRequiresNewline: false, closeRequiresNewline: false
         },
-        codeGroup: {
-            openTag: "", closeTag: "",
+        container: {
+            openTag: (_name: string) => "",
+            closeTag: (_name: string) => "",
             openRequiresNewline: false, closeRequiresNewline: false
         }
     }

--- a/src/menubar/menubar.ts
+++ b/src/menubar/menubar.ts
@@ -14,6 +14,7 @@ type MenuEntry = {
     showByDefault: boolean;
     cmd: Command;
     customEntry: boolean;
+    isActive?: (state: import("prosemirror-state").EditorState) => boolean;
 };
 
 /**
@@ -110,6 +111,10 @@ class MenuView implements PluginView {
                 item.dom.style.opacity = active ? "1" : "0.4";
                 // And make it unclickable.
                 item.dom.setAttribute("disabled", (!active).toString());
+            } else if (item.isActive) {
+                const active = item.isActive(this.view.state);
+                item.dom.style.opacity = active ? "1" : "0.4";
+                item.dom.setAttribute("disabled", (!active).toString());
             }
         }
     }
@@ -165,14 +170,15 @@ function createDefaultMenu(outerView: EditorView, os: OS, tagConf: TagConfigurat
     // Create the list of menu entries.
     const items: MenuEntry[] = [];
 
-    const customMenuItems = customEntries?.map(entry => createMenuItem(entry.title, entry.hoverText, () => { entry.callback(); return true; }, entry.buttonVisibility, true));
+    const customMenuItems = customEntries?.map(entry => {
+        const item = createMenuItem(entry.title, entry.hoverText, () => { entry.callback(); return true; }, entry.buttonVisibility, true);
+        item.isActive = entry.isActive;
+        return item;
+    });
     if (customMenuItems !== undefined)
         items.push(...customMenuItems);
 
-    // The DEBUG label will be dropped in case we are *not* in debug mode.
-    // eslint-disable-next-line no-unused-labels
-    DEBUG: {
-        items.push(
+    items.push(
             ...[
                 // Insert Coq command
                 createMenuItem("Math↓", `Insert new verified math block underneath (${keyBinding("q")})`, getCmdInsertCode(InsertionPlace.Below, tagConf)),
@@ -190,7 +196,13 @@ function createDefaultMenu(outerView: EditorView, os: OS, tagConf: TagConfigurat
                 createMenuItem("<strong>?</strong>", "Make selection a hint element", teacherOnlyWrapper(wrapInHint(tagConf)), teacherOnly),
                 createMenuItem("↑", "Lift selected node (Reverts the effect of making a 'hint' or 'input area')", teacherOnlyWrapper(wpLift(tagConf)), teacherOnly),
                 createMenuItem("🗑️", "Delete selection", teacherOnlyWrapper(deleteSelection(tagConf)), teacherOnly),
-            ],
+            ])
+
+
+    // The DEBUG label will be dropped in case we are *not* in debug mode.
+    // eslint-disable-next-line no-unused-labels
+    DEBUG: {
+        items.push(
             createMenuItem("DUMP DOC", "", (state, dispatch) => {
                 if (dispatch) console.log("\x1b[33m[DEBUG]\x1b[0m dumped doc", JSON.stringify(state.doc.toJSON()));
                 return true;

--- a/src/schema/schema.ts
+++ b/src/schema/schema.ts
@@ -7,7 +7,7 @@ export const SchemaCell = {
 	MathDisplay: "math_display",
 	Code: "code",
 	Newline: "newline",
-	CodeGroup: "code_group"
+	Container: "container"
 } as const;
 
 export type SchemaKeys = keyof typeof SchemaCell;
@@ -38,7 +38,7 @@ export const WaterproofSchema = new Schema<SchemaNames | "doc" | "text" >({
 		markdown: {
 			block: true,
 			content: "text*",
-			group: "cell containercontent codegroupcontent",
+			group: "cell containercontent containercell",
 			parseDOM: [{tag: "markdown", preserveWhitespace: "full"}],
 			atom: true,
 			toDOM: () => {
@@ -51,7 +51,7 @@ export const WaterproofSchema = new Schema<SchemaNames | "doc" | "text" >({
 		//#region Hint
 		hint: {
 			content: "containercontent+",
-			group: "cell codegroupcontent",
+			group: "cell containercell",
 			attrs: {
 				title: {default: "💡 Hint"},
 				shown: {default: false}
@@ -66,7 +66,7 @@ export const WaterproofSchema = new Schema<SchemaNames | "doc" | "text" >({
 		//#region input
 		input: {
 			content: "containercontent+",
-			group: "cell codegroupcontent",
+			group: "cell containercell",
 			attrs: {
 				status: {default: null}
 			},
@@ -80,7 +80,7 @@ export const WaterproofSchema = new Schema<SchemaNames | "doc" | "text" >({
 		//#region Code
 		code: {
 			content: "text*",// content is of type text
-			group: "cell containercontent codegroupcontent",
+			group: "cell containercontent containercell",
 			code: true,
 			atom: true, // doesn't have directly editable content (content is edited through codemirror)
 			toDOM(node) { return ["WaterproofCode", node.attrs, 0] } // <WaterproofCode></WaterproofCode> cells
@@ -91,7 +91,7 @@ export const WaterproofSchema = new Schema<SchemaNames | "doc" | "text" >({
 		/////// MATH DISPLAY //////
 		//#region math-display
 		math_display: {
-			group: "math cell containercontent codegroupcontent",
+			group: "math cell containercontent containercell",
 			content: "text*",
 			atom: true,
 			code: true,
@@ -100,18 +100,21 @@ export const WaterproofSchema = new Schema<SchemaNames | "doc" | "text" >({
 		//#endregion
 
 		newline: {
-			group: "cell containercontent codegroupcontent",
+			group: "cell containercontent containercell",
 			toDOM(node) { return ["WaterproofNewline", node.attrs]},
 			selectable: false,
 		},
 
-		/////// CODE GROUP //////
-		//#region code_group
-		code_group: {
-			content: "codegroupcontent+",
+		/////// CONTAINER //////
+		//#region container
+		container: {
+			content: "containercell+",
 			group: "cell",
-			toDOM: () => {
-				return ["WaterproofCodeGroup", {class: "codegroup"}, 0];
+			attrs: {
+				name: {default: ""}
+			},
+			toDOM: (node) => {
+				return ["WaterproofContainer", {class: "container", name: node.attrs.name}, 0];
 			}
 		},
 		//#endregion

--- a/src/schema/schema.ts
+++ b/src/schema/schema.ts
@@ -6,7 +6,8 @@ export const SchemaCell = {
 	Markdown: "markdown",
 	MathDisplay: "math_display",
 	Code: "code",
-	Newline: "newline"
+	Newline: "newline",
+	CodeGroup: "code_group"
 } as const;
 
 export type SchemaKeys = keyof typeof SchemaCell;
@@ -37,7 +38,7 @@ export const WaterproofSchema = new Schema<SchemaNames | "doc" | "text" >({
 		markdown: {
 			block: true,
 			content: "text*",
-			group: "cell containercontent",
+			group: "cell containercontent codegroupcontent",
 			parseDOM: [{tag: "markdown", preserveWhitespace: "full"}],
 			atom: true,
 			toDOM: () => {
@@ -50,7 +51,7 @@ export const WaterproofSchema = new Schema<SchemaNames | "doc" | "text" >({
 		//#region Hint
 		hint: {
 			content: "containercontent+",
-			group: "cell",
+			group: "cell codegroupcontent",
 			attrs: {
 				title: {default: "💡 Hint"},
 				shown: {default: false}
@@ -65,7 +66,7 @@ export const WaterproofSchema = new Schema<SchemaNames | "doc" | "text" >({
 		//#region input
 		input: {
 			content: "containercontent+",
-			group: "cell",
+			group: "cell codegroupcontent",
 			attrs: {
 				status: {default: null}
 			},
@@ -79,7 +80,7 @@ export const WaterproofSchema = new Schema<SchemaNames | "doc" | "text" >({
 		//#region Code
 		code: {
 			content: "text*",// content is of type text
-			group: "cell containercontent",
+			group: "cell containercontent codegroupcontent",
 			code: true,
 			atom: true, // doesn't have directly editable content (content is edited through codemirror)
 			toDOM(node) { return ["WaterproofCode", node.attrs, 0] } // <WaterproofCode></WaterproofCode> cells
@@ -90,7 +91,7 @@ export const WaterproofSchema = new Schema<SchemaNames | "doc" | "text" >({
 		/////// MATH DISPLAY //////
 		//#region math-display
 		math_display: {
-			group: "math cell containercontent",
+			group: "math cell containercontent codegroupcontent",
 			content: "text*",
 			atom: true,
 			code: true,
@@ -99,9 +100,20 @@ export const WaterproofSchema = new Schema<SchemaNames | "doc" | "text" >({
 		//#endregion
 
 		newline: {
-			group: "cell containercontent",
+			group: "cell containercontent codegroupcontent",
 			toDOM(node) { return ["WaterproofNewline", node.attrs]},
 			selectable: false,
-		}
+		},
+
+		/////// CODE GROUP //////
+		//#region code_group
+		code_group: {
+			content: "codegroupcontent+",
+			group: "cell",
+			toDOM: () => {
+				return ["WaterproofCodeGroup", {class: "codegroup"}, 0];
+			}
+		},
+		//#endregion
 	}
 });

--- a/src/schema/schema.ts
+++ b/src/schema/schema.ts
@@ -114,7 +114,7 @@ export const WaterproofSchema = new Schema<SchemaNames | "doc" | "text" >({
 				name: {default: ""}
 			},
 			toDOM: (node) => {
-				return ["WaterproofContainer", {class: "container", name: node.attrs.name}, 0];
+				return ["div", {class: "container", "data-name": node.attrs.name}, 0];
 			}
 		},
 		//#endregion

--- a/src/schema/schema.ts
+++ b/src/schema/schema.ts
@@ -38,7 +38,7 @@ export const WaterproofSchema = new Schema<SchemaNames | "doc" | "text" >({
 		markdown: {
 			block: true,
 			content: "text*",
-			group: "cell containercontent containercell",
+			group: "cell hintinputcontent containercontent",
 			parseDOM: [{tag: "markdown", preserveWhitespace: "full"}],
 			atom: true,
 			toDOM: () => {
@@ -50,8 +50,8 @@ export const WaterproofSchema = new Schema<SchemaNames | "doc" | "text" >({
 		/////// HINT //////
 		//#region Hint
 		hint: {
-			content: "containercontent+",
-			group: "cell containercell",
+			content: "hintinputcontent+",
+			group: "cell containercontent",
 			attrs: {
 				title: {default: "💡 Hint"},
 				shown: {default: false}
@@ -65,8 +65,8 @@ export const WaterproofSchema = new Schema<SchemaNames | "doc" | "text" >({
 		/////// Input Area //////
 		//#region input
 		input: {
-			content: "containercontent+",
-			group: "cell containercell",
+			content: "hintinputcontent+",
+			group: "cell containercontent",
 			attrs: {
 				status: {default: null}
 			},
@@ -80,7 +80,7 @@ export const WaterproofSchema = new Schema<SchemaNames | "doc" | "text" >({
 		//#region Code
 		code: {
 			content: "text*",// content is of type text
-			group: "cell containercontent containercell",
+			group: "cell hintinputcontent containercontent",
 			code: true,
 			atom: true, // doesn't have directly editable content (content is edited through codemirror)
 			toDOM(node) { return ["WaterproofCode", node.attrs, 0] } // <WaterproofCode></WaterproofCode> cells
@@ -91,7 +91,7 @@ export const WaterproofSchema = new Schema<SchemaNames | "doc" | "text" >({
 		/////// MATH DISPLAY //////
 		//#region math-display
 		math_display: {
-			group: "math cell containercontent containercell",
+			group: "math cell hintinputcontent containercontent",
 			content: "text*",
 			atom: true,
 			code: true,
@@ -100,7 +100,7 @@ export const WaterproofSchema = new Schema<SchemaNames | "doc" | "text" >({
 		//#endregion
 
 		newline: {
-			group: "cell containercontent containercell",
+			group: "cell hintinputcontent containercontent",
 			toDOM(node) { return ["WaterproofNewline", node.attrs]},
 			selectable: false,
 		},
@@ -108,7 +108,7 @@ export const WaterproofSchema = new Schema<SchemaNames | "doc" | "text" >({
 		/////// CONTAINER //////
 		//#region container
 		container: {
-			content: "containercell+",
+			content: "containercontent+",
 			group: "cell",
 			attrs: {
 				name: {default: ""}

--- a/src/serialization/DocumentSerializer.ts
+++ b/src/serialization/DocumentSerializer.ts
@@ -47,6 +47,15 @@ export abstract class DocumentSerializer {
      * of the node are newline nodes they will be skipped and the next nodes will be returned (if they exist).
      */
     abstract serializeHint(hintNode: Node, parentNode: string | null, neighbors: (skipNewlines: boolean) => {nodeAbove: string | null, nodeBelow: string | null}): string;
+
+    /**
+     * Describes how to turn a code_group node into a string representation.
+     * This node can have children (including input areas and hints), so you probably want to call `this.serializeNode` on every child node.
+     * @param codeGroupNode The code_group node that is going to be serialized
+     * @param parentNode The parent node of this node (if it has one)
+     * @param neighbors Function that upon calling will return the neighbors of the node being serialized.
+     */
+    abstract serializeCodeGroup(codeGroupNode: Node, parentNode: string | null, neighbors: (skipNewlines: boolean) => {nodeAbove: string | null, nodeBelow: string | null}): string;
     
     serializeText(node: Node): string {
         return node.textContent;
@@ -68,6 +77,7 @@ export abstract class DocumentSerializer {
             case WaterproofSchema.nodes.math_display: return this.serializeMath(node, parent, neighbors);
             case WaterproofSchema.nodes.input: return this.serializeInput(node, parent, neighbors);
             case WaterproofSchema.nodes.hint: return this.serializeHint(node, parent, neighbors);
+            case WaterproofSchema.nodes.code_group: return this.serializeCodeGroup(node, parent, neighbors);
             case WaterproofSchema.nodes.text: return this.serializeText(node);
             case WaterproofSchema.nodes.newline: return this.serializeNewline();
             default:
@@ -141,5 +151,23 @@ export class DefaultTagSerializer extends DocumentSerializer {
             textContent.push(output);
         });
         return this.tagConf.hint.openTag(title) + textContent.join("") + this.tagConf.hint.closeTag;
+    }
+
+    serializeCodeGroup(node: Node): string {
+        const textContent: string[] = [];
+        node.forEach((child, _, idx) => {
+            const nodeDirectlyAbove = node.maybeChild(idx - 1);
+            const nodeDirectlyBelow = node.maybeChild(idx + 1);
+            const func = (skipNewlines: boolean): { nodeAbove: string | null; nodeBelow: string | null } => {
+                let above = nodeDirectlyAbove?.type.name ?? null;
+                let below = nodeDirectlyBelow?.type.name ?? null;
+                if (above === "newline" && skipNewlines) above = node.maybeChild(idx - 2)?.type.name ?? null;
+                if (below === "newline" && skipNewlines) below = node.maybeChild(idx + 2)?.type.name ?? null;
+                return {nodeAbove: above, nodeBelow: below};
+            };
+            const output = this.serializeNode(child, "code_group", func);
+            textContent.push(output);
+        });
+        return this.tagConf.codeGroup.openTag + textContent.join("") + this.tagConf.codeGroup.closeTag;
     }
 }

--- a/src/serialization/DocumentSerializer.ts
+++ b/src/serialization/DocumentSerializer.ts
@@ -49,13 +49,14 @@ export abstract class DocumentSerializer {
     abstract serializeHint(hintNode: Node, parentNode: string | null, neighbors: (skipNewlines: boolean) => {nodeAbove: string | null, nodeBelow: string | null}): string;
 
     /**
-     * Describes how to turn a code_group node into a string representation.
+     * Describes how to turn a container node into a string representation.
      * This node can have children (including input areas and hints), so you probably want to call `this.serializeNode` on every child node.
-     * @param codeGroupNode The code_group node that is going to be serialized
+     * The container's name can be retrieved via `containerNode.attrs.name`.
+     * @param containerNode The container node that is going to be serialized
      * @param parentNode The parent node of this node (if it has one)
      * @param neighbors Function that upon calling will return the neighbors of the node being serialized.
      */
-    abstract serializeCodeGroup(codeGroupNode: Node, parentNode: string | null, neighbors: (skipNewlines: boolean) => {nodeAbove: string | null, nodeBelow: string | null}): string;
+    abstract serializeContainer(containerNode: Node, parentNode: string | null, neighbors: (skipNewlines: boolean) => {nodeAbove: string | null, nodeBelow: string | null}): string;
     
     serializeText(node: Node): string {
         return node.textContent;
@@ -77,7 +78,7 @@ export abstract class DocumentSerializer {
             case WaterproofSchema.nodes.math_display: return this.serializeMath(node, parent, neighbors);
             case WaterproofSchema.nodes.input: return this.serializeInput(node, parent, neighbors);
             case WaterproofSchema.nodes.hint: return this.serializeHint(node, parent, neighbors);
-            case WaterproofSchema.nodes.code_group: return this.serializeCodeGroup(node, parent, neighbors);
+            case WaterproofSchema.nodes.container: return this.serializeContainer(node, parent, neighbors);
             case WaterproofSchema.nodes.text: return this.serializeText(node);
             case WaterproofSchema.nodes.newline: return this.serializeNewline();
             default:
@@ -153,7 +154,8 @@ export class DefaultTagSerializer extends DocumentSerializer {
         return this.tagConf.hint.openTag(title) + textContent.join("") + this.tagConf.hint.closeTag;
     }
 
-    serializeCodeGroup(node: Node): string {
+    serializeContainer(node: Node): string {
+        const name = node.attrs.name as string;
         const textContent: string[] = [];
         node.forEach((child, _, idx) => {
             const nodeDirectlyAbove = node.maybeChild(idx - 1);
@@ -165,9 +167,9 @@ export class DefaultTagSerializer extends DocumentSerializer {
                 if (below === "newline" && skipNewlines) below = node.maybeChild(idx + 2)?.type.name ?? null;
                 return {nodeAbove: above, nodeBelow: below};
             };
-            const output = this.serializeNode(child, "code_group", func);
+            const output = this.serializeNode(child, "container", func);
             textContent.push(output);
         });
-        return this.tagConf.codeGroup.openTag + textContent.join("") + this.tagConf.codeGroup.closeTag;
+        return this.tagConf.container.openTag(name) + textContent.join("") + this.tagConf.container.closeTag(name);
     }
 }

--- a/src/styles/container.css
+++ b/src/styles/container.css
@@ -1,0 +1,7 @@
+.container {
+    display: block;
+    position: relative;
+    padding-left: 8px;
+    border-left: 4px dashed var(--wp-buttonBorder);
+    margin: 4px 0;
+}

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -9,6 +9,9 @@ import "./style.css";
 // for hints
 import "./hints.css";
 
+// for containers (multilean blocks)
+import "./container.css";
+
 // for menubar
 import "./menubar.css";
 


### PR DESCRIPTION
This PR is largely the product of Claude. I have reviewed the non-testing code in detail and am happy with it. I have skimmed the tests. I am aware that some of the tests are not strictly testing the lean files, but these are more integration tests of the functionality added, rather than lean-specific tests. This PR has a [companion PR](https://github.com/impermeable/waterproof-vscode/pull/329) in waterproof-vscode.

### Description
Adds generic container functionality. Containers have a name, which should be specified by the downstream application.

### Changes
- Adds container block
- Fixes various bugs with wrapping/insertion of nodes and newlines
- Added unit tests for these bugs/bugs that happened during development of the feature.

### Testing this PR
Build along with the companion PR.
Test all the wrapping/insert functionality in .lean files.
Spotcheck the wrapping/insert in .mv files.
Due to the buttons being disabled, this requires building in debug mode to use the buttons.
