### PR TITLE
refactor file progress messages so that the vs-code side is unaware o…

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -98,6 +98,32 @@ export class MappingError extends Error {
     constructor(message: string) { super("[MappingError] " + message); }
 }
 
+/**
+ * Represents information about the progress of file processing.
+ */
+export type SimpleProgressInfo = {
+    /** Range for which the processing info was reported. */
+    range: {
+        start: { line: number, character: number };
+        end: { line: number, character: number };
+    };
+    /** Kind of progress that was reported. */
+    kind?: FileProgressKind;
+};
+
+/**
+ * Parameters for progress update messages.
+ */
+export type SimpleProgressParams = {
+    numberOfLines: number;
+    progress: SimpleProgressInfo[];
+};
+
+export enum FileProgressKind {
+    Processing = 1,
+    FatalError = 2,
+}
+
 export type MenuBarEntry = {
     /** The text to show in the menubar */
     title: string;

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -8,7 +8,7 @@ import { EditorView } from "prosemirror-view";
 import { undo, redo, history } from "prosemirror-history";
 import { constructDocument } from "./document/construct-document";
 
-import { DocChange, InputAreaStatus, WrappingDocChange, HistoryChange, Severity, OffsetDiagnostic, MappingError, NodeUpdateError, TextUpdateError, DocumentSerializer, Positioned, ThemeStyle, WaterproofEditorConfig, TextContentOfSpecifier } from "./api";
+import { DocChange, InputAreaStatus, WrappingDocChange, HistoryChange, Severity, OffsetDiagnostic, MappingError, NodeUpdateError, TextUpdateError, DocumentSerializer, Positioned, ThemeStyle, WaterproofEditorConfig, TextContentOfSpecifier, SimpleProgressParams } from "./api";
 import { CODE_PLUGIN_KEY, codePlugin } from "./codeview";
 import { createHintPlugin } from "./hinting";
 import { INPUT_AREA_PLUGIN_KEY, inputAreaPlugin } from "./inputArea";
@@ -569,8 +569,27 @@ export class WaterproofEditor {
 		this._view.dispatch(trans);
 	}
 
-	public reportProgress(current: number, total: number, text?: string): void {
-		this._progressBar.reportProgress(current, total, text);
+	/**
+	 * Handle a progress update from the server.
+	 * @param params Contains numberOfLines and progress information
+	 */
+	public handleProgressUpdate(params: SimpleProgressParams): void {
+		const { numberOfLines, progress } = params;
+		if (progress.length === 0) {
+			this.removeBusyIndicators();
+			this._progressBar.reportProgress(numberOfLines, numberOfLines, "File verified");
+		} else {
+			const verifiedLineNumber = progress[0].range.start.line + 1;
+			this._progressBar.reportProgress(verifiedLineNumber, numberOfLines, `Verified file up to line: ${verifiedLineNumber}`);
+		}
+	}
+
+	/**
+	 * Handle execution info from the server.
+	 * @param range Object with 'from' property indicating the execution position offset
+	 */
+	public handleExecutionInfo(range: {from: number}): void {
+		this.setBusyIndicator(range.from);
 	}
 
 	public startSpinner(): void { this._progressBar.startSpinner(); }


### PR DESCRIPTION
Add `handleProgressUpdate` / `handleExecutionInfo` to `WaterproofEditor`; export progress types
 
**Description:**
 
Adds two new public methods to `WaterproofEditor`:
 
- `handleProgressUpdate(params: SimpleProgressParams)`: encapsulates the logic for updating the progress bar based on LSP file progress notifications. Clears busy indicators and reports "File verified" when `progress` is empty; otherwise reports the verified line number.
- `handleExecutionInfo(range: {from: number})`: sets the busy indicator to the given offset.
 
Also exports `SimpleProgressInfo`, `SimpleProgressParams`, and `FileProgressKind` from `src/api/types.ts`, replacing the now-deleted definitions in `waterproof-vscode/shared/ProgressInfo.ts`.

At first, we didn't report "File verified" when `progress` is empty, this is what caused the bar to get stuck, even after checking was completed.
 
**Partially fixes #319.** The progress bar no longer gets stuck, but finer-grained progress depends on Verso/LSP improvements.

The main fix of this PR is the progress bar getting stuck, but I also figured that some refactoring was in order. Mainly because of the vscode side knowing too much regarding how file progress is handled on the editor side.