### PR TITLE
fix: removed mod-enter default block creation

### DIFF
--- a/src/embedded-codemirror/embeddedCodemirror.ts
+++ b/src/embedded-codemirror/embeddedCodemirror.ts
@@ -3,7 +3,6 @@ import { Node as PNode, Schema } from "prosemirror-model";
 import { TextSelection } from "prosemirror-state";
 import { Decoration, DecorationSource, EditorView, NodeView } from "prosemirror-view";
 import { MovementDirection, MovementUnit } from "./types";
-import { exitCode } from "prosemirror-commands";
 import { keybindings } from "./embedded-codemirror-keymap";
 
 /**

--- a/src/embedded-codemirror/embeddedCodemirror.ts
+++ b/src/embedded-codemirror/embeddedCodemirror.ts
@@ -233,22 +233,13 @@ export class EmbeddedCodeMirrorEditor implements NodeView {
 
     // Setup codemirror keymap
 	embeddedCodeMirrorKeymap(): KeyBinding[] {
-		const view = this._outerView;
 
-		// 'Mod' is a platform independent 'Ctrl'/'Cmd'
 		return [
 			...keybindings,
 			{ key: "ArrowUp", run: this.maybeEscape(MovementUnit.line, MovementDirection.backward) },
 			{ key: "ArrowLeft", run: this.maybeEscape(MovementUnit.character, MovementDirection.backward) },
 			{ key: "ArrowDown", run: this.maybeEscape(MovementUnit.line, MovementDirection.forward) },
 			{ key: "ArrowRight", run: this.maybeEscape(MovementUnit.character, MovementDirection.forward) },
-			{
-				key: "Mod-Enter", run: () => {
-					if (!exitCode(view.state, view.dispatch)) return false
-					view.focus()
-					return true
-				}
-			},
 		]
 	}
 }


### PR DESCRIPTION
### Description+Changes
This PR removes the default block creation of ProseMirror when pressing `Ctrl+Enter`. This was caused by the `exitCode` function. From the ProseMirror documentation:
```typescript
/**
When the selection is in a node with a truthy
[`code`](https://prosemirror.net/docs/ref/#model.NodeSpec.code) property in its spec, create a
default block after the code block, and move the cursor there.
*/
declare const exitCode: Command;
```
So all this was doing was create an unwanted default block (a.k.a. a markdown block). 

### Testing this PR
Pressing `Ctrl+Enter` inside an input area should have no effect. 

Closes #74 