### PR TITLE
Fix for trimmed whitespace issue 

### DIFF
--- a/src/editor.ts
+++ b/src/editor.ts
@@ -141,6 +141,28 @@ export class WaterproofEditor {
 		this._editorConfig.api.editorReady();
 	}
 
+	refreshDocument(content: string, version: number = 1) {
+		if (!this._view) return;
+		if (this._mapping && this._mapping.version == version) return;
+
+		const blocks = this._editorConfig.documentConstructor(content);
+		const proseDoc = constructDocument(blocks);
+
+		this._mapping = new Mapping(blocks, version, this._editorConfig.tagConfiguration, this._serializer);
+		const newState = EditorState.create({
+			doc: proseDoc,
+			plugins: this._view.state.plugins,
+			schema: WaterproofSchema
+		});
+
+		this._view.updateState(newState);
+
+		/** Ask for line numbers */
+		this.updateLineNumbers();
+		this.handleScroll(window.innerHeight);
+
+	}
+
 	private get state(): EditorState | undefined {
 		return this._view?.state;
 	}


### PR DESCRIPTION
PR that goes along with the PR under the same name for waterproof-vscode.

Description
This is a pull request to partially solve the trimming whitespace Issue https://github.com/impermeable/waterproof-vscode/issues/136. We now reload the editor only if the file has changed on save, and always give a warning to the user when the trim trailing whitespace setting is on.

Changes
The editor effectively re-initializes if the underlying file has changed when the file was saved, which only really occurs when the trim trailing whitespace setting is on. This makes it clunky if auto save is on, but the warning should prevent this.

Testing this PR
When initializing the extension, the warning should appear on the bottom left of the screen. Moreover, if you turn on trim trailing whitespace setting, and then add a couple of spaces at the end of one of the input areas, and press ctrl+s, then the editor will refresh the text in the editor with the content at disk (i.e no whitespace) while also staying in the same position in the document.