### PR TITLE
fix: moved MessageHandlerEditor interface from vscode to editor

### DIFF
--- a/src/api/MessageHandlerEditor.ts
+++ b/src/api/MessageHandlerEditor.ts
@@ -1,0 +1,29 @@
+import type { Completion } from "@codemirror/autocomplete";
+import type { HistoryChange, OffsetDiagnostic, ThemeStyle } from "./types";
+import type { InputAreaStatus } from "./InputAreaStatus";
+
+/**
+ * API surface expected by the extension-side webview message router.
+ *
+ * This contract lives in the editor package because the extension sends
+ * messages to an editor instance and should depend on the editor's public API.
+ */
+export interface MessageHandlerEditor {
+	init: (value: string, version: number) => void;
+	insertSymbol: (symbolUnicode: string) => boolean;
+	handleSnippet: (template: string) => void;
+	replaceRange: (start: number, end: number, text: string) => boolean;
+	handleCompletions: (completions: Completion[]) => void;
+	setInputAreaStatus: (statuses: InputAreaStatus[]) => void;
+	setShowLineNumbers: (show: boolean) => void;
+	setShowMenuItems: (show: boolean) => void;
+	handleHistoryChange: (historyChange: HistoryChange) => void;
+	updateLockingState: (teacherModeEnabled: boolean) => void;
+	removeBusyIndicators: () => void;
+	reportProgress: (at: number, numberOfLines: number, label: string) => void;
+	setBusyIndicator: (from: number) => void;
+	setActiveDiagnostics: (diagnostics: Array<OffsetDiagnostic>) => void;
+	startSpinner: () => void;
+	stopSpinner: () => void;
+	updateNodeViewThemes: (theme: ThemeStyle) => void;
+}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -6,6 +6,7 @@ export { EditorState, Transaction } from "prosemirror-state";
 // Export QedStatus type
 export { InputAreaStatus } from "./InputAreaStatus";
 export { Severity, SeverityLabel, SeverityLabelMap } from "./Severity";
+export type { MessageHandlerEditor } from "./MessageHandlerEditor";
 
 export * from "./types";
 

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -8,7 +8,7 @@ import { EditorView } from "prosemirror-view";
 import { undo, redo, history } from "prosemirror-history";
 import { constructDocument } from "./document/construct-document";
 
-import { DocChange, InputAreaStatus, WrappingDocChange, HistoryChange, Severity, OffsetDiagnostic, MappingError, NodeUpdateError, TextUpdateError, DocumentSerializer, Positioned, ThemeStyle, WaterproofEditorConfig, TextContentOfSpecifier } from "./api";
+import { DocChange, InputAreaStatus, WrappingDocChange, HistoryChange, Severity, OffsetDiagnostic, MappingError, NodeUpdateError, TextUpdateError, DocumentSerializer, Positioned, ThemeStyle, WaterproofEditorConfig, TextContentOfSpecifier, MessageHandlerEditor } from "./api";
 import { CODE_PLUGIN_KEY, codePlugin } from "./codeview";
 import { createHintPlugin } from "./hinting";
 import { INPUT_AREA_PLUGIN_KEY, inputAreaPlugin } from "./inputArea";
@@ -40,7 +40,7 @@ export type DiagnosticObjectProse = {message: string, start: number, end: number
 /**
  * WaterproofEditor class. Configured via the WaterproofEditorConfig object.
  */
-export class WaterproofEditor {
+export class WaterproofEditor implements MessageHandlerEditor {
 
 	private readonly _editorConfig: WaterproofEditorConfig;
 


### PR DESCRIPTION
### Description
Moved the `MessageHandlerEditor` interface from waterproof-vscode to waterproof-editor. Then I made sure that the `WaterproofEditor` class implements this interface. 

This should allow for better type-checking and goto functionality of IDEs

Requires branch `editor-interface-type-checking-fix` in waterproof-vscode

Companion PR: impermeable/waterproof-vscode#350