### PR TITLE
332 bug lean starting subproof gives scary warning

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -188,6 +188,8 @@ export interface OffsetDiagnostic {
     severity: Severity;
     startOffset: number;
     endOffset: number;
+    // If true, keep the red squiggle but suppress this entry from the lint panel.
+    hideFromBottomPanel?: boolean;
 }
 
 export enum ThemeStyle {

--- a/src/codeview/nodeview.ts
+++ b/src/codeview/nodeview.ts
@@ -402,8 +402,10 @@ export class CodeBlockView extends EmbeddedCodeMirrorEditor {
 		if (startPos === undefined) return [];
 
 		// We use the outer editor instance to query for diagnostics in the range of this codemirror instance.
+		const inInputArea = this.partOfInputArea();
+
 		const diags = this.editorInstance.getPartialDiagnosticsInRange(startPos, startPos + _view.state.doc.length + 1)
-			.filter(d => !(d.hideFromBottomPanel ?? false))
+			.filter(d => !(inInputArea && (d.hideFromBottomPanel ?? false)))
 			.map(d => {
 				// The codemirror range is from 0 to _view.state.doc.length + 1.
 				// We need to translate the position that we get from the diagnostic object into this range by subtracting the starting

--- a/src/codeview/nodeview.ts
+++ b/src/codeview/nodeview.ts
@@ -402,14 +402,16 @@ export class CodeBlockView extends EmbeddedCodeMirrorEditor {
 		if (startPos === undefined) return [];
 
 		// We use the outer editor instance to query for diagnostics in the range of this codemirror instance.
-		const diags = this.editorInstance.getPartialDiagnosticsInRange(startPos, startPos + _view.state.doc.length + 1).map(d => {
-			// The codemirror range is from 0 to _view.state.doc.length + 1.
-			// We need to translate the position that we get from the diagnostic object into this range by subtracting the starting
-			// position of this codemirror instance.
-			return this.preprocessDiagnostic(Math.max(d.start - startPos - 1, 0),
-				Math.min(d.end - startPos - 1, _view.state.doc.length),
-				d.message, d.severity);
-		});
+		const diags = this.editorInstance.getPartialDiagnosticsInRange(startPos, startPos + _view.state.doc.length + 1)
+			.filter(d => !(d.hideFromBottomPanel ?? false))
+			.map(d => {
+				// The codemirror range is from 0 to _view.state.doc.length + 1.
+				// We need to translate the position that we get from the diagnostic object into this range by subtracting the starting
+				// position of this codemirror instance.
+				return this.preprocessDiagnostic(Math.max(d.start - startPos - 1, 0),
+					Math.min(d.end - startPos - 1, _view.state.doc.length),
+					d.message, d.severity);
+			});
 
 		// Update the version of the diagnostics we are using.
 		this.lastUsedDiagnosticsVersion = this.editorInstance.diagnosticsVersion;

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -35,7 +35,13 @@ import { Mapping } from "./mapping";
 import { ProgressBar } from "./progressBar";
 
 /** Type that contains a coq diagnostics object fit for use in the ProseMirror editor context. */
-export type DiagnosticObjectProse = {message: string, start: number, end: number, severity: Severity};
+export type DiagnosticObjectProse = {
+	message: string,
+	start: number,
+	end: number,
+	severity: Severity,
+	hideFromBottomPanel?: boolean,
+};
 
 /**
  * WaterproofEditor class. Configured via the WaterproofEditorConfig object.
@@ -632,8 +638,7 @@ export class WaterproofEditor {
 			const end = map.textOffsetToPmIndex(d.endOffset);
 
 			return {
-				message: d.message,
-				severity: d.severity,
+				...d,
 				start,
 				end
 			}
@@ -660,9 +665,9 @@ export class WaterproofEditor {
 		const end = map.textOffsetToPmIndex(toRemove.endOffset);
 
 		const proseDiag: DiagnosticObjectProse = {
-			start, end,
-			message: toRemove.message,
-			severity: toRemove.severity
+			...toRemove,
+			start,
+			end
 		}
 
 		const oldLength = this.currentProseDiagnostics.length;
@@ -705,10 +710,9 @@ export class WaterproofEditor {
 			const end = map.textOffsetToPmIndex(diag.endOffset);
 			if (start >= end) continue;
 			this.currentProseDiagnostics[i] = {
-				message: diag.message,
+				...diag,
 				start,
 				end,
-				severity: diag.severity
 			};
 		}
 		// diagnostics have changed
@@ -750,10 +754,9 @@ export class WaterproofEditor {
 			return (value.start <= high && value.end >= low && value.severity <= truncationLevel);
 		}).map(d => {
 			return {
-				message: d.message,
+				...d,
 				start: Math.max(d.start, low),
 				end: Math.min(d.end, high),
-				severity: d.severity
 			}
 		});
 	}


### PR DESCRIPTION
From the vscode side, we now receive the `hideFromBottomPanel` diagnostic message. This is to prevent messages like `unsolved goals` in a subproof from scaring the user by not showing them below an input panel.

To test this PR, checkout branch 332-bug-lean-starting-a-subproof-gives-a-scary-warning in `impermeable/waterproof-vscode`. Start a subproof by using a `\.` character. The error message should no longer appear on the bottom of the input area (only if the unsolved goals is inside the input area). Other error messages should be uneffected.  

This is done to resolve impermeable/waterproof-vscode#332. However, I am not quite satisfied with the result, because it also hides the red squiggly line that would normally appear below the subproof dot. This squiggle shows the user that the subproof has not been solved yet. From the issue description, it wasn't really clear to me what the desired end result was. If desired, I can also show a shorter error message instead of the whole thing. However, if we want to HIDE the error message AND still show the squiggle, the best way (without any hacks) would be to ask the CodeMirror maintainer Marijn if we could do this using the linter. Currently, you can say whether you want the error to show a tooltip, but you cannot prevent it from showing up in the bottom panel (trust me, I tried). 

If the current approach is already sufficient and does not need to red squiggle, then please go ahead and merge this.