### PR TITLE
Do not include coverage data in tarball

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -13,3 +13,4 @@ package-lock.json
 /tsconfig.json
 /tsconfig.tsbuildinfo
 sonar-project.properties
+/coverage


### PR DESCRIPTION
Update .npmignore to not include coverage data in the tarball.

