### PR TITLE
fix: markdown and math fields don't get highlighted with a single click when they are not editable

### DIFF
--- a/__tests__/SwitchableView.test.ts
+++ b/__tests__/SwitchableView.test.ts
@@ -1,0 +1,129 @@
+/**
+ * @jest-environment jsdom
+ */
+
+// AI-generated tests
+
+import { EditorState } from "prosemirror-state";
+import { Node as PNode } from "prosemirror-model";
+import { INPUT_AREA_PLUGIN_KEY, inputAreaPlugin } from "../src/inputArea";
+import { WaterproofSchema } from "../src/schema";
+import { SWITCHABLE_VIEW_PLUGIN_KEY } from "../src/markup-views";
+import { SwitchableView } from "../src/markup-views/switchable-view";
+import { EditorView } from "prosemirror-view";
+
+/**
+ * doc
+ *  └─ markdown("outside")            -- sibling of `input`, never editable in student mode
+ *  └─ input
+ *      └─ markdown("inside")         -- inside `input`, editable in student mode
+ */
+function buildDoc(): PNode {
+  const outsideMarkdown = WaterproofSchema.nodes.markdown.create(
+    null,
+    WaterproofSchema.text("outside"),
+  );
+  const insideMarkdown = WaterproofSchema.nodes.markdown.create(
+    null,
+    WaterproofSchema.text("inside"),
+  );
+  const inputNode = WaterproofSchema.nodes.input.create(null, insideMarkdown);
+  return WaterproofSchema.nodes.doc.create(null, [outsideMarkdown, inputNode]);
+}
+
+function makeState(teacher: boolean, plugins: unknown[] = [inputAreaPlugin]) {
+  let state = EditorState.create({
+    doc: buildDoc(),
+    schema: WaterproofSchema,
+    plugins: plugins as never,
+  });
+  state = state.apply(state.tr.setMeta(INPUT_AREA_PLUGIN_KEY, { teacher }));
+  return state;
+}
+
+/** Position immediately before the first node matching `predicate` (the NodeView getPos contract). */
+function findNodePos(doc: PNode, predicate: (n: PNode) => boolean): number {
+  let result = -1;
+  doc.descendants((node, pos) => {
+    if (result !== -1) return false;
+    if (predicate(node)) {
+      result = pos;
+      return false;
+    }
+    return true;
+  });
+  if (result === -1) throw new Error("node not found");
+  return result;
+}
+
+/** Minimal fake outer view: SwitchableView only reads `.state` and calls `.dispatch`. */
+function fakeOuterView(state: EditorState) {
+  return {
+    state,
+    dispatch: jest.fn(),
+    editable: true,
+  } as unknown as EditorView;
+}
+
+function makeSwitchableView(state: EditorState, pos: number) {
+  const node = state.doc.nodeAt(pos)!;
+  const outerView = fakeOuterView(state);
+  const sv = new SwitchableView(
+    () => pos,
+    outerView,
+    node.textContent,
+    node,
+    SWITCHABLE_VIEW_PLUGIN_KEY,
+    "markdown",
+    (input) => input,
+    [],
+  );
+  return { sv, outerView };
+}
+
+describe("SwitchableView click-to-edit locking", () => {
+  test("student mode: clicking a cell outside the input area is a no-op", () => {
+    const state = makeState(false);
+    const pos = findNodePos(
+      state.doc,
+      (n) =>
+        n.type === WaterproofSchema.nodes.markdown &&
+        n.textContent === "outside",
+    );
+    const { sv, outerView } = makeSwitchableView(state, pos);
+
+    sv.dom.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+    expect(outerView.dispatch).not.toHaveBeenCalled();
+  });
+
+  test("student mode: clicking a cell inside the input area selects it", () => {
+    const state = makeState(false);
+    const pos = findNodePos(
+      state.doc,
+      (n) =>
+        n.type === WaterproofSchema.nodes.markdown &&
+        n.textContent === "inside",
+    );
+    const { sv, outerView } = makeSwitchableView(state, pos);
+
+    sv.dom.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+    expect(outerView.dispatch).toHaveBeenCalledTimes(1);
+  });
+
+  test("teacher mode: clicking a cell outside the input area still selects it", () => {
+    const state = makeState(true);
+    const pos = findNodePos(
+      state.doc,
+      (n) =>
+        n.type === WaterproofSchema.nodes.markdown &&
+        n.textContent === "outside",
+    );
+    const { sv, outerView } = makeSwitchableView(state, pos);
+
+    sv.dom.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+    expect(outerView.dispatch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/__tests__/SwitchableView.test.ts
+++ b/__tests__/SwitchableView.test.ts
@@ -4,13 +4,13 @@
 
 // AI-generated tests
 
-import { EditorState } from "prosemirror-state";
 import { Node as PNode } from "prosemirror-model";
 import { INPUT_AREA_PLUGIN_KEY, inputAreaPlugin } from "../src/inputArea";
 import { WaterproofSchema } from "../src/schema";
 import { SWITCHABLE_VIEW_PLUGIN_KEY } from "../src/markup-views";
 import { SwitchableView } from "../src/markup-views/switchable-view";
 import { EditorView } from "prosemirror-view";
+import { EditorState, Plugin } from "prosemirror-state";
 
 /**
  * doc
@@ -31,11 +31,11 @@ function buildDoc(): PNode {
   return WaterproofSchema.nodes.doc.create(null, [outsideMarkdown, inputNode]);
 }
 
-function makeState(teacher: boolean, plugins: unknown[] = [inputAreaPlugin]) {
+function makeState(teacher: boolean, plugins: Plugin[] = [inputAreaPlugin]) {
   let state = EditorState.create({
     doc: buildDoc(),
     schema: WaterproofSchema,
-    plugins: plugins as never,
+    plugins,
   });
   state = state.apply(state.tr.setMeta(INPUT_AREA_PLUGIN_KEY, { teacher }));
   return state;

--- a/__tests__/editor.test.ts
+++ b/__tests__/editor.test.ts
@@ -28,6 +28,11 @@ import {
 } from "../src/api";
 import { CodeBlock } from "../src/document";
 import { configuration } from "../src/markdown-defaults";
+import { WaterproofSchema } from "../src";
+
+import { EditorView } from "prosemirror-view";
+import * as inputAreaModule from "../src/inputArea";
+import { NodeType } from "prosemirror-model";
 
 const cfg: WaterproofEditorConfig = {
   api: {
@@ -50,8 +55,8 @@ const cfg: WaterproofEditorConfig = {
 function makeEditor(): WaterproofEditor {
   const el = document.createElement("div");
   jest.spyOn(WaterproofEditor.prototype, "handleScroll").mockImplementation();
-  //@ts-expect-error private method
   jest
+    //@ts-expect-error private method
     .spyOn(WaterproofEditor.prototype, "informCodemirrorViews")
     .mockImplementation();
   const editor = new WaterproofEditor(el, cfg, ThemeStyle.Light);
@@ -185,5 +190,87 @@ describe("methods with no view initialised", () => {
 
   test("insertSymbol returns false", () => {
     expect(makeUninitializedEditor().insertSymbol("α")).toBe(false);
+  });
+});
+
+describe("handleMouseDown", () => {
+  let isEditableSpy: jest.SpyInstance;
+  let editor: WaterproofEditor;
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    editor = makeEditor();
+    isEditableSpy = jest.spyOn(inputAreaModule, "isPositionEditable");
+  });
+
+  function simulateMouseDown(
+    nodeType: NodeType | null,
+    isEditable: boolean = false,
+    targetIsNull = false,
+  ) {
+    isEditableSpy.mockReturnValue(isEditable);
+
+    const fakeView = {
+      posAtDOM: jest.fn().mockReturnValue(0),
+      state: {
+        doc: {
+          resolve: jest.fn().mockReturnValue({
+            node: () => ({ type: nodeType }),
+          }),
+        },
+      },
+    };
+
+    const event = new MouseEvent("mousedown");
+    const preventDefaultSpy = jest.spyOn(event, "preventDefault");
+
+    // Conditionally mock the target
+    Object.defineProperty(event, "target", {
+      value: targetIsNull ? null : document.createElement("span"),
+    });
+
+    //@ts-expect-error private method
+    const result = editor.handleMouseDown(fakeView, event);
+
+    return { result, preventDefaultSpy };
+  }
+
+  test("null target -> prevents default and returns undefined", () => {
+    const { result, preventDefaultSpy } = simulateMouseDown(null, false, true);
+
+    expect(result).toBeUndefined();
+    expect(preventDefaultSpy).toHaveBeenCalled();
+    expect(isEditableSpy).not.toHaveBeenCalled();
+  });
+
+  test("math_display + not editable -> returns true (event handled)", () => {
+    const { result, preventDefaultSpy } = simulateMouseDown(
+      WaterproofSchema.nodes.math_display,
+      false,
+    );
+
+    expect(result).toBe(true);
+    expect(preventDefaultSpy).not.toHaveBeenCalled();
+  });
+
+  test("math_display + editable -> returns false (event not handled)", () => {
+    const { result, preventDefaultSpy } = simulateMouseDown(
+      WaterproofSchema.nodes.math_display,
+      true,
+    );
+
+    expect(result).toBe(false);
+    expect(preventDefaultSpy).not.toHaveBeenCalled();
+  });
+
+  test("other nodes (e.g. code_block) -> prevents default and returns undefined", () => {
+    const { result, preventDefaultSpy } = simulateMouseDown(
+      WaterproofSchema.nodes.code_block,
+      false,
+    );
+
+    expect(result).toBeUndefined();
+    expect(preventDefaultSpy).toHaveBeenCalled();
+    expect(isEditableSpy).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/inputArea.test.ts
+++ b/__tests__/inputArea.test.ts
@@ -1,0 +1,113 @@
+/**
+ * @jest-environment jsdom
+ */
+
+// AI-generated tests
+
+import { EditorState, TextSelection } from "prosemirror-state";
+import { Node as PNode } from "prosemirror-model";
+import {
+  INPUT_AREA_PLUGIN_KEY,
+  inputAreaPlugin,
+  isPositionEditable,
+} from "../src/inputArea";
+import { WaterproofSchema } from "../src/schema";
+
+/**
+ * doc
+ *  └─ markdown("outside")            -- sibling of `input`, never editable in student mode
+ *  └─ input
+ *      └─ markdown("inside")         -- inside `input`, editable in student mode
+ */
+function buildDoc(): PNode {
+  const outsideMarkdown = WaterproofSchema.nodes.markdown.create(
+    null,
+    WaterproofSchema.text("outside"),
+  );
+  const insideMarkdown = WaterproofSchema.nodes.markdown.create(
+    null,
+    WaterproofSchema.text("inside"),
+  );
+  const inputNode = WaterproofSchema.nodes.input.create(null, insideMarkdown);
+  return WaterproofSchema.nodes.doc.create(null, [outsideMarkdown, inputNode]);
+}
+
+/** Position of the first character of the text matching `text`, wherever it is in the doc. */
+function textPos(doc: PNode, text: string): number {
+  let found = -1;
+  doc.descendants((node, pos) => {
+    if (found !== -1) return false;
+    if (node.isText && node.text === text) {
+      found = pos;
+      return false;
+    }
+    return true;
+  });
+  if (found === -1) throw new Error(`text not found: ${text}`);
+  return found;
+}
+
+function makeState(teacher: boolean, plugins: unknown[] = [inputAreaPlugin]) {
+  let state = EditorState.create({
+    doc: buildDoc(),
+    schema: WaterproofSchema,
+    plugins: plugins as never,
+  });
+  state = state.apply(state.tr.setMeta(INPUT_AREA_PLUGIN_KEY, { teacher }));
+  return state;
+}
+
+describe("isPositionEditable", () => {
+  test("teacher mode is editable everywhere, regardless of position", () => {
+    const state = makeState(true);
+    expect(isPositionEditable(state, textPos(state.doc, "outside"))).toBe(true);
+    expect(isPositionEditable(state, textPos(state.doc, "inside"))).toBe(true);
+  });
+
+  test("student mode: editable inside an input node", () => {
+    const state = makeState(false);
+    expect(isPositionEditable(state, textPos(state.doc, "inside"))).toBe(true);
+  });
+
+  test("student mode: not editable outside an input node", () => {
+    const state = makeState(false);
+    expect(isPositionEditable(state, textPos(state.doc, "outside"))).toBe(
+      false,
+    );
+  });
+
+  test("falls back to student-mode rules when the plugin isn't registered", () => {
+    const state = EditorState.create({
+      doc: buildDoc(),
+      schema: WaterproofSchema,
+      plugins: [],
+    });
+    expect(isPositionEditable(state, textPos(state.doc, "inside"))).toBe(true);
+    expect(isPositionEditable(state, textPos(state.doc, "outside"))).toBe(
+      false,
+    );
+  });
+});
+
+describe("inputAreaPlugin editable prop", () => {
+  test("tracks isPositionEditable at the current selection", () => {
+    let state = makeState(false);
+    const editableProp = inputAreaPlugin.props.editable as (
+      s: EditorState,
+    ) => boolean;
+
+    state = state.apply(
+      state.tr.setSelection(
+        TextSelection.create(state.doc, textPos(state.doc, "outside")),
+      ),
+    );
+    expect(editableProp(state)).toBe(false);
+
+    state = state.apply(
+      state.tr.setSelection(
+        TextSelection.create(state.doc, textPos(state.doc, "inside")),
+      ),
+    );
+    expect(editableProp(state)).toBe(true);
+  });
+});

--- a/__tests__/inputArea.test.ts
+++ b/__tests__/inputArea.test.ts
@@ -4,7 +4,7 @@
 
 // AI-generated tests
 
-import { EditorState, TextSelection } from "prosemirror-state";
+import { EditorState, Plugin, TextSelection } from "prosemirror-state";
 import { Node as PNode } from "prosemirror-model";
 import {
   INPUT_AREA_PLUGIN_KEY,
@@ -47,11 +47,11 @@ function textPos(doc: PNode, text: string): number {
   return found;
 }
 
-function makeState(teacher: boolean, plugins: unknown[] = [inputAreaPlugin]) {
+function makeState(teacher: boolean, plugins: Plugin[] = [inputAreaPlugin]) {
   let state = EditorState.create({
     doc: buildDoc(),
     schema: WaterproofSchema,
-    plugins: plugins as never,
+    plugins,
   });
   state = state.apply(state.tr.setMeta(INPUT_AREA_PLUGIN_KEY, { teacher }));
   return state;

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -644,40 +644,9 @@ export class WaterproofEditor implements MessageHandlerEditor {
     state = this._view.state;
     const trans = state.tr;
 
-    /* TODO: The check that makes sure we are allowed to insert is pretty much the
-			same as in `inputArea.ts` and could maybe be improved. */
-
-    const inputAreaPluginState = INPUT_AREA_PLUGIN_KEY.getState(state);
-
-    // Early return if the plugin state is undefined.
-    if (inputAreaPluginState === undefined) return false;
-    const { teacher } = inputAreaPluginState;
-
-    // If we are in teacher mode (ie. not locked) than
-    // 	 we are always able to insert.
-    if (teacher) {
-      this.createAndDispatchInsertionTransaction(
-        trans,
-        symbolUnicode,
-        from,
-        to,
-      );
-      return true;
-    }
-
-    const { $from } = state.selection;
-
-    let isEditable = false;
-    state.doc.nodesBetween($from.pos, $from.pos, (node) => {
-      if (node.type === WaterproofSchema.nodes.input) {
-        isEditable = true;
-      }
-    });
-
-    if (!isEditable) return false;
+    if (!isPositionEditable(state, state.selection.$from.pos)) return false;
 
     this.createAndDispatchInsertionTransaction(trans, symbolUnicode, from, to);
-
     return true;
   }
 

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -339,7 +339,7 @@ export class WaterproofEditor implements MessageHandlerEditor {
     }
   }
 
-  private handleMouseDown = (
+  private readonly handleMouseDown = (
     view: EditorView,
     event: MouseEvent,
   ): boolean | void => {

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -35,7 +35,11 @@ import {
 } from "./api";
 import { CODE_PLUGIN_KEY, codePlugin } from "./codeview";
 import { createHintPlugin } from "./hinting";
-import { INPUT_AREA_PLUGIN_KEY, inputAreaPlugin } from "./inputArea";
+import {
+  INPUT_AREA_PLUGIN_KEY,
+  inputAreaPlugin,
+  isPositionEditable,
+} from "./inputArea";
 import { WaterproofSchema } from "./schema";
 import {
   SWITCHABLE_VIEW_PLUGIN_KEY,
@@ -326,8 +330,11 @@ export class WaterproofEditor implements MessageHandlerEditor {
 
           const posAtDomTarget = view.posAtDOM(domTarget, 0);
           const nodeAtDomTarget = view.state.doc.resolve(posAtDomTarget).node();
-          if (nodeAtDomTarget.type === WaterproofSchema.nodes.math_display)
-            return;
+          if (nodeAtDomTarget.type === WaterproofSchema.nodes.math_display) {
+            // If the node is not editable, we tell ProseMirror that we have handled the event,
+            // this makes it so that single clicking does not select the whole math node.
+            return !isPositionEditable(view.state, posAtDomTarget);
+          }
 
           event.preventDefault();
         },

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -321,23 +321,7 @@ export class WaterproofEditor implements MessageHandlerEditor {
         drop: (view, event) => {
           event.preventDefault();
         },
-        mousedown: (view, event) => {
-          const domTarget = event.target as Node | null;
-          if (domTarget === null) {
-            event.preventDefault();
-            return;
-          }
-
-          const posAtDomTarget = view.posAtDOM(domTarget, 0);
-          const nodeAtDomTarget = view.state.doc.resolve(posAtDomTarget).node();
-          if (nodeAtDomTarget.type === WaterproofSchema.nodes.math_display) {
-            // If the node is not editable, we tell ProseMirror that we have handled the event,
-            // this makes it so that single clicking does not select the whole math node.
-            return !isPositionEditable(view.state, posAtDomTarget);
-          }
-
-          event.preventDefault();
-        },
+        mousedown: this.handleMouseDown,
       },
     });
     this._view = view;
@@ -353,6 +337,25 @@ export class WaterproofEditor implements MessageHandlerEditor {
       devTools.applyDevTools(view);
     }
   }
+
+  private handleMouseDown = (
+    view: EditorView,
+    event: MouseEvent,
+  ): boolean | void => {
+    const domTarget = event.target as Node | null;
+    if (domTarget === null) {
+      event.preventDefault();
+      return;
+    }
+
+    const posAtDomTarget = view.posAtDOM(domTarget, 0);
+    const nodeAtDomTarget = view.state.doc.resolve(posAtDomTarget).node();
+    if (nodeAtDomTarget.type === WaterproofSchema.nodes.math_display) {
+      return !isPositionEditable(view.state, posAtDomTarget);
+    }
+
+    event.preventDefault();
+  };
 
   /** Create initial prosemirror state */
   private createState(proseDoc: ProseNode): EditorState {

--- a/src/inputArea.ts
+++ b/src/inputArea.ts
@@ -50,32 +50,35 @@ const InputAreaPluginSpec: PluginSpec<IInputAreaPluginState> = {
     },
   },
   props: {
-    editable: (state) => {
-      // Get locked and globalLock states from the plugin.
-      const teacher = INPUT_AREA_PLUGIN_KEY.getState(state)?.teacher ?? false;
-
-      // In teacher mode, everything is editable by default.
-      if (teacher) return true;
-
-      // Get the from selection component.
-      const { $from } = state.selection;
-
-      // Assume non-editable.
-      let isEditable = false;
-
-      // Check if the current selection is inside an input area.
-      state.doc.nodesBetween($from.pos, $from.pos, (node) => {
-        if (node.type === WaterproofSchema.nodes.input) {
-          // If so, this cell is editable.
-          isEditable = true;
-        }
-      });
-
-      // Return editable state.
-      return isEditable;
-    },
+    editable: (state) => isPositionEditable(state, state.selection.$from.pos),
   },
 };
+
+/**
+ * Determine whether the given position in the document is currently editable.
+ * In teacher mode everything is editable; in student mode only positions
+ * inside an `input` node are editable.
+ */
+export function isPositionEditable(state: EditorState, pos: number): boolean {
+  const teacher = INPUT_AREA_PLUGIN_KEY.getState(state)?.teacher ?? false;
+
+  // In teacher mode, everything is editable by default.
+  if (teacher) return true;
+
+  // Assume non-editable.
+  let isEditable = false;
+
+  // Check if the current selection is inside an input area.
+  state.doc.nodesBetween(pos, pos, (node) => {
+    if (node.type === WaterproofSchema.nodes.input) {
+      // If so, this cell is editable.
+      isEditable = true;
+    }
+  });
+
+  // Return editable state.
+  return isEditable;
+}
 
 // Export the input area plugin for use in the editor.
 export const inputAreaPlugin = new Plugin(InputAreaPluginSpec);

--- a/src/markup-views/switchable-view/SwitchableView.ts
+++ b/src/markup-views/switchable-view/SwitchableView.ts
@@ -4,6 +4,7 @@ import { RenderedView } from "./RenderedView";
 import { NodeSelection, PluginKey } from "prosemirror-state";
 import { Node as PNode } from "prosemirror-model";
 import { WaterproofSchema } from "../../schema";
+import { isPositionEditable } from "../../inputArea";
 
 /**
  * Abstract class for a switchable view.
@@ -88,12 +89,13 @@ export class SwitchableView implements NodeView {
     // eventHandler for the onclick event.
     // Creates a new node selection that selects 'this' node.
     const eventHandler = () => {
-      const tr = outerView.state.tr;
       const pos = getPos();
       if (pos === undefined) {
         console.error("why pos undefined?!");
         return;
       }
+      if (!isPositionEditable(outerView.state, pos)) return;
+      const tr = outerView.state.tr;
       const nodeSel = new NodeSelection(outerView.state.doc.resolve(pos));
       tr.setSelection(nodeSel);
       outerView.dispatch(tr);

--- a/src/markup-views/switchable-view/SwitchableView.ts
+++ b/src/markup-views/switchable-view/SwitchableView.ts
@@ -22,7 +22,7 @@ export class SwitchableView implements NodeView {
   /** The outer prosemirror editor */
   private readonly _outerView: EditorView;
   /** The node that is passed when constructing the NodeView */
-  private readonly _node: PNode;
+  private _node: PNode;
 
   /** Represents whether the view is currently updating */
   private _updating: boolean;

--- a/src/markup-views/switchable-view/SwitchableView.ts
+++ b/src/markup-views/switchable-view/SwitchableView.ts
@@ -18,22 +18,22 @@ export class SwitchableView implements NodeView {
   /** Whether we are in rendered mode */
   private inRenderMode: boolean = true;
   /** The place to insert the views into */
-  private _place: HTMLElement;
+  private readonly _place: HTMLElement;
   /** The outer prosemirror editor */
-  private _outerView: EditorView;
+  private readonly _outerView: EditorView;
   /** The node that is passed when constructing the NodeView */
-  private _node: PNode;
+  private readonly _node: PNode;
 
   /** Represents whether the view is currently updating */
   private _updating: boolean;
-  private _getPos: () => number | undefined;
+  private readonly _getPos: () => number | undefined;
 
-  private _pluginKey: PluginKey;
+  private readonly _pluginKey: PluginKey;
 
-  private _emptyClassName: string;
-  private _viewClassName: string;
-  private _editorClassName: string;
-  private _renderedClassName: string;
+  private readonly _emptyClassName: string;
+  private readonly _viewClassName: string;
+  private readonly _editorClassName: string;
+  private readonly _renderedClassName: string;
 
   public get content() {
     return this._node.textContent;


### PR DESCRIPTION
### Description
Fixes a bug where single clicking on a markdown cell would highlight the entire thing. The same bug also made it so that you can't "highlight" using a single click like you can with regular text. 

Math nodes had the same behaviour, so I also fixed this bug for those. 

### Testing this PR
Click once on a math/markdown node and notice that it no longer highlights. Click on it twice, and it does highlight the text (as is usual).

If the text is editable (either through an `:::input` block or in teacher mode) it should still work like normal.

Closes #14 