### PR TITLE
Add student hidden node that is only visible in teacher mode

### DIFF
--- a/__tests__/commands/all-insertions.test.ts
+++ b/__tests__/commands/all-insertions.test.ts
@@ -51,6 +51,12 @@ const tagConf: TagConfiguration = {
     openRequiresNewline: false,
     closeRequiresNewline: false,
   },
+  studentHidden: {
+    openTag: "<student-hidden>",
+    closeTag: "</student-hidden>",
+    openRequiresNewline: false,
+    closeRequiresNewline: false,
+  },
 };
 
 const initialStateCode = {

--- a/__tests__/commands/wrap-commands.test.ts
+++ b/__tests__/commands/wrap-commands.test.ts
@@ -45,6 +45,12 @@ const leanConfig: TagConfiguration = {
     openRequiresNewline: true,
     closeRequiresNewline: true,
   },
+  studentHidden: {
+    openTag: ":::studentHidden\n",
+    closeTag: "\n:::",
+    openRequiresNewline: true,
+    closeRequiresNewline: true,
+  },
 };
 const leanSerializer = new DefaultTagSerializer(leanConfig);
 

--- a/__tests__/container.test.ts
+++ b/__tests__/container.test.ts
@@ -9,23 +9,24 @@ import {
   isContainerBlock,
 } from "../src/document/blocks";
 import { HintBlock, ContainerBlock } from "../src/document";
-import { Mapping, Range, WaterproofDocument } from "../src/api";
-import {
-  CodeBlock,
-  InputAreaBlock,
-  MarkdownBlock,
-  MathDisplayBlock,
-  NewlineBlock,
-} from "../src/document";
+import { CodeBlock, InputAreaBlock, MarkdownBlock } from "../src/document";
 import { configuration } from "../src/markdown-defaults";
 import { DefaultTagSerializer } from "../src/serialization/DocumentSerializer";
 import { constructDocument } from "../src/document";
 import { sanityCheckTree } from "./mapping/util";
 import { TagConfiguration } from "../src/api";
 import { wrapInContainer, wpLift } from "../src/commands";
+import {
+  applyCommand,
+  createTestMapping,
+  docChildTypes,
+  groupingChildCases,
+  serializeBlocks,
+  stateWithNodeSelAt,
+} from "./helpers";
 
-import { EditorState, NodeSelection, Transaction } from "prosemirror-state";
-import { Fragment, Node as PNode } from "prosemirror-model";
+import { EditorState } from "prosemirror-state";
+import { Fragment } from "prosemirror-model";
 import { WaterproofSchema } from "../src/schema";
 import { checkInputArea } from "../src/commands/command-helpers";
 
@@ -42,47 +43,6 @@ const multileanConfig: TagConfiguration = {
   },
 };
 const multileanSerializer = new DefaultTagSerializer(multileanConfig);
-
-function createTestMapping(blocks: WaterproofDocument) {
-  const mapping = new Mapping(blocks, 1, config, serializer);
-  return mapping.getMapping();
-}
-
-// ============================================================
-// Test utility helpers
-// ============================================================
-
-/** Constructs a document from blocks and serializes it with the given serializer (defaults to `serializer`). */
-function serializeBlocks(blocks: WaterproofDocument, ser = serializer): string {
-  return ser.serializeDocument(constructDocument(blocks));
-}
-
-/** Creates an EditorState with a NodeSelection at `pos`. */
-function stateWithNodeSelAt(doc: PNode, pos: number): EditorState {
-  const state = EditorState.create({ doc });
-  return state.apply(
-    state.tr.setSelection(NodeSelection.create(state.doc, pos)),
-  );
-}
-
-/** Applies a ProseMirror command to `state`, returning the resulting state or null if not dispatched. */
-function applyCommand(
-  state: EditorState,
-  cmd: (s: EditorState, dispatch?: (tr: Transaction) => void) => boolean,
-): EditorState | null {
-  let newState: EditorState | null = null;
-  cmd(state, (tr) => {
-    newState = state.apply(tr);
-  });
-  return newState;
-}
-
-/** Returns the type names of all direct children of a doc node. */
-function docChildTypes(doc: PNode): string[] {
-  const types: string[] = [];
-  doc.forEach((child) => types.push(child.type.name));
-  return types;
-}
 
 // ============================================================
 // Parsing tests — the .mv parser (statemachine.ts) does not
@@ -107,126 +67,21 @@ Some markdown content
 // ============================================================
 
 describe("container serialization", () => {
-  test("serialize container with markdown", () => {
-    const innerBlocks = [
-      new MarkdownBlock(
-        "Some text",
-        { from: 14, to: 23 },
-        { from: 14, to: 23 },
+  // With empty tags, the expected output equals the container's string content.
+  test.each(groupingChildCases())(
+    "serialize container with $child",
+    ({ stringContent, range, innerRange, innerBlocks }) => {
+      const cg = new ContainerBlock(
+        stringContent,
+        "test",
+        range,
+        innerRange,
         0,
-      ),
-    ];
-    const cg = new ContainerBlock(
-      "Some text",
-      "test",
-      { from: 0, to: 28 },
-      { from: 14, to: 23 },
-      0,
-      innerBlocks,
-    );
-    expect(serializeBlocks([cg])).toBe("Some text");
-  });
-
-  test("serialize container with code block", () => {
-    const innerBlocks = [
-      new CodeBlock(
-        "def x := 1",
-        { from: 14, to: 37 },
-        { from: 21, to: 31 },
-        0,
-      ),
-    ];
-    const cg = new ContainerBlock(
-      "```lean4\ndef x := 1\n```",
-      "test",
-      { from: 0, to: 42 },
-      { from: 14, to: 37 },
-      0,
-      innerBlocks,
-    );
-    expect(serializeBlocks([cg])).toBe("```lean4\ndef x := 1\n```");
-  });
-
-  test("serialize container with input area", () => {
-    const inputInnerBlocks = [
-      new MarkdownBlock(
-        "input text",
-        { from: 26, to: 36 },
-        { from: 26, to: 36 },
-        0,
-      ),
-    ];
-    const innerBlocks = [
-      new InputAreaBlock(
-        "input text",
-        { from: 14, to: 49 },
-        { from: 26, to: 36 },
-        0,
-        inputInnerBlocks,
-      ),
-    ];
-    const cg = new ContainerBlock(
-      "<input-area>input text</input-area>",
-      "test",
-      { from: 0, to: 54 },
-      { from: 14, to: 49 },
-      0,
-      innerBlocks,
-    );
-    expect(serializeBlocks([cg])).toBe("<input-area>input text</input-area>");
-  });
-
-  test("serialize container with hint", () => {
-    const hintInnerBlocks = [
-      new MarkdownBlock(
-        "hint text",
-        { from: 40, to: 49 },
-        { from: 40, to: 49 },
-        0,
-      ),
-    ];
-    const innerBlocks = [
-      new HintBlock(
-        "hint text",
-        "My Hint",
-        { from: 14, to: 56 },
-        { from: 40, to: 49 },
-        0,
-        hintInnerBlocks,
-      ),
-    ];
-    const cg = new ContainerBlock(
-      '<hint title="My Hint">hint text</hint>',
-      "test",
-      { from: 0, to: 61 },
-      { from: 14, to: 52 },
-      0,
-      innerBlocks,
-    );
-    expect(serializeBlocks([cg])).toBe(
-      '<hint title="My Hint">hint text</hint>',
-    );
-  });
-
-  test("serialize container with math_display", () => {
-    const innerBlocks = [
-      new MathDisplayBlock(
-        "x^2",
-        { from: 14, to: 21 },
-        { from: 16, to: 19 },
-        0,
-      ),
-    ];
-    const cg = new ContainerBlock(
-      "$$x^2$$",
-      "test",
-      { from: 0, to: 26 },
-      { from: 14, to: 21 },
-      0,
-      innerBlocks,
-    );
-    expect(serializeBlocks([cg])).toBe("$$x^2$$");
-  });
+        innerBlocks,
+      );
+      expect(serializeBlocks([cg], serializer)).toBe(stringContent);
+    },
+  );
 
   test("serialize container with non-empty tags (multilean)", () => {
     const innerBlocks = [
@@ -248,27 +103,6 @@ describe("container serialization", () => {
     expect(serializeBlocks([cg], multileanSerializer)).toBe(
       "::::multilean\nSome content\n::::",
     );
-  });
-
-  test("serialize container with multiple children", () => {
-    const innerBlocks = [
-      new MarkdownBlock("intro", { from: 14, to: 19 }, { from: 14, to: 19 }, 0),
-      new CodeBlock(
-        "def x := 1",
-        { from: 19, to: 42 },
-        { from: 26, to: 36 },
-        0,
-      ),
-    ];
-    const cg = new ContainerBlock(
-      "intro```lean4\ndef x := 1\n```",
-      "test",
-      { from: 0, to: 47 },
-      { from: 14, to: 42 },
-      0,
-      innerBlocks,
-    );
-    expect(serializeBlocks([cg])).toBe("intro```lean4\ndef x := 1\n```");
   });
 });
 
@@ -293,7 +127,7 @@ describe("container mapping", () => {
         ),
       ],
     );
-    const tree = createTestMapping([cg]);
+    const tree = createTestMapping([cg], config, serializer);
 
     expect(tree.root.children.length).toBe(1);
     const cgNode = tree.root.children[0];
@@ -327,7 +161,7 @@ describe("container mapping", () => {
       [inputInner],
     );
 
-    const tree = createTestMapping([cg]);
+    const tree = createTestMapping([cg], config, serializer);
 
     expect(tree.root.children.length).toBe(1);
     const cgNode = tree.root.children[0];
@@ -365,7 +199,7 @@ describe("container mapping", () => {
       0,
       [hintBlock],
     );
-    const tree = createTestMapping([cg]);
+    const tree = createTestMapping([cg], config, serializer);
 
     const cgNode = tree.root.children[0];
     expect(cgNode.type).toBe("container");

--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -1,0 +1,204 @@
+import { EditorState, NodeSelection, Transaction } from "prosemirror-state";
+import { Node as PNode } from "prosemirror-model";
+import {
+  DocumentSerializer,
+  Mapping,
+  TagConfiguration,
+  WaterproofDocument,
+} from "../src/api";
+import {
+  Block,
+  BlockRange,
+  CodeBlock,
+  HintBlock,
+  InputAreaBlock,
+  MarkdownBlock,
+  MathDisplayBlock,
+  constructDocument,
+} from "../src/document";
+
+// ============================================================
+// Shared test utility helpers
+// ============================================================
+
+/** Constructs a document from blocks and serializes it with the given serializer. */
+export function serializeBlocks(
+  blocks: WaterproofDocument,
+  serializer: DocumentSerializer,
+): string {
+  return serializer.serializeDocument(constructDocument(blocks));
+}
+
+/** Creates a Mapping for `blocks` and returns the underlying tree. */
+export function createTestMapping(
+  blocks: WaterproofDocument,
+  config: TagConfiguration,
+  serializer: DocumentSerializer,
+) {
+  const mapping = new Mapping(blocks, 1, config, serializer);
+  return mapping.getMapping();
+}
+
+/** Creates an EditorState with a NodeSelection at `pos`. */
+export function stateWithNodeSelAt(doc: PNode, pos: number): EditorState {
+  const state = EditorState.create({ doc });
+  return state.apply(
+    state.tr.setSelection(NodeSelection.create(state.doc, pos)),
+  );
+}
+
+/** Applies a ProseMirror command to `state`, returning the resulting state or null if not dispatched. */
+export function applyCommand(
+  state: EditorState,
+  cmd: (s: EditorState, dispatch?: (tr: Transaction) => void) => boolean,
+): EditorState | null {
+  let newState: EditorState | null = null;
+  cmd(state, (tr) => {
+    newState = state.apply(tr);
+  });
+  return newState;
+}
+
+/** Returns the type names of all direct children of a doc node. */
+export function docChildTypes(doc: PNode): string[] {
+  const types: string[] = [];
+  doc.forEach((child) => types.push(child.type.name));
+  return types;
+}
+
+// ============================================================
+// Shared fixtures for grouping blocks (container, student_hidden)
+// ============================================================
+
+export type GroupingChildCase = {
+  /** Name of the (top-most) child block type, used in test titles. */
+  child: string;
+  /** The string content of the grouping block (its serialized children). */
+  stringContent: string;
+  /** Range of the entire grouping block, including its tags. */
+  range: BlockRange;
+  /** Range of the grouping block's inner content, excluding its tags. */
+  innerRange: BlockRange;
+  /** The child blocks of the grouping block. */
+  innerBlocks: Block[];
+};
+
+/**
+ * Inner-block fixtures for blocks that group child blocks together
+ * (`ContainerBlock`, `StudentHiddenBlock`). Ranges assume the grouping
+ * block's open tag occupies offsets 0-13 and are mutually consistent
+ * (children exactly tile the parent's inner range), so the fixtures can be
+ * used for serialization as well as mapping tests.
+ * A fresh set of blocks is created on every call.
+ */
+export function groupingChildCases(): GroupingChildCase[] {
+  return [
+    {
+      child: "markdown",
+      stringContent: "Some text",
+      range: { from: 0, to: 28 },
+      innerRange: { from: 14, to: 23 },
+      innerBlocks: [
+        new MarkdownBlock(
+          "Some text",
+          { from: 14, to: 23 },
+          { from: 14, to: 23 },
+          0,
+        ),
+      ],
+    },
+    {
+      child: "code",
+      stringContent: "```lean4\ndef x := 1\n```",
+      range: { from: 0, to: 42 },
+      innerRange: { from: 14, to: 37 },
+      innerBlocks: [
+        new CodeBlock(
+          "def x := 1",
+          { from: 14, to: 37 },
+          { from: 21, to: 31 },
+          0,
+        ),
+      ],
+    },
+    {
+      child: "input area",
+      stringContent: "<input-area>input text</input-area>",
+      range: { from: 0, to: 54 },
+      innerRange: { from: 14, to: 49 },
+      innerBlocks: [
+        new InputAreaBlock(
+          "input text",
+          { from: 14, to: 49 },
+          { from: 26, to: 36 },
+          0,
+          [
+            new MarkdownBlock(
+              "input text",
+              { from: 26, to: 36 },
+              { from: 26, to: 36 },
+              0,
+            ),
+          ],
+        ),
+      ],
+    },
+    {
+      child: "hint",
+      stringContent: '<hint title="My Hint">hint text</hint>',
+      range: { from: 0, to: 57 },
+      innerRange: { from: 14, to: 52 },
+      innerBlocks: [
+        new HintBlock(
+          "hint text",
+          "My Hint",
+          { from: 14, to: 52 },
+          { from: 40, to: 49 },
+          0,
+          [
+            new MarkdownBlock(
+              "hint text",
+              { from: 40, to: 49 },
+              { from: 40, to: 49 },
+              0,
+            ),
+          ],
+        ),
+      ],
+    },
+    {
+      child: "math_display",
+      stringContent: "$$x^2$$",
+      range: { from: 0, to: 26 },
+      innerRange: { from: 14, to: 21 },
+      innerBlocks: [
+        new MathDisplayBlock(
+          "x^2",
+          { from: 14, to: 21 },
+          { from: 16, to: 19 },
+          0,
+        ),
+      ],
+    },
+    {
+      child: "multiple children (markdown + code)",
+      stringContent: "intro```lean4\ndef x := 1\n```",
+      range: { from: 0, to: 47 },
+      innerRange: { from: 14, to: 42 },
+      innerBlocks: [
+        new MarkdownBlock(
+          "intro",
+          { from: 14, to: 19 },
+          { from: 14, to: 19 },
+          0,
+        ),
+        new CodeBlock(
+          "def x := 1",
+          { from: 19, to: 42 },
+          { from: 26, to: 36 },
+          0,
+        ),
+      ],
+    },
+  ];
+}

--- a/__tests__/mapping/nodeupdate.test.ts
+++ b/__tests__/mapping/nodeupdate.test.ts
@@ -71,6 +71,12 @@ const leanConfig = {
     openRequiresNewline: true,
     closeRequiresNewline: true,
   },
+  studentHidden: {
+    openTag: ":::studentHidden\n",
+    closeTag: "\n:::",
+    openRequiresNewline: true,
+    closeRequiresNewline: true,
+  },
 };
 const leanSerializer = new DefaultTagSerializer(leanConfig);
 

--- a/__tests__/student-hidden.test.ts
+++ b/__tests__/student-hidden.test.ts
@@ -9,10 +9,12 @@ import {
   isMathDisplayBlock,
   isNewlineBlock,
   isContainerBlock,
+  isStudentHiddenBlock,
 } from "../src/document/blocks";
 import {
   Block,
   BlockRange,
+  CodeBlock,
   ContainerBlock,
   MarkdownBlock,
   StudentHiddenBlock,
@@ -20,15 +22,16 @@ import {
 } from "../src/document";
 import { BLOCK_NAME } from "../src/document/blocks/block";
 import { configuration } from "../src/markdown-defaults";
-import {
-  DefaultTagSerializer,
-  SerializationError,
-} from "../src/serialization/DocumentSerializer";
+import { TagConfiguration } from "../src/api";
+import { DefaultTagSerializer } from "../src/serialization/DocumentSerializer";
 import { sanityCheckTree } from "./mapping/util";
+import { wpLift, wrapInStudentHidden } from "../src/commands";
 import {
+  applyCommand,
   createTestMapping,
   groupingChildCases,
   serializeBlocks,
+  stateWithNodeSelAt,
 } from "./helpers";
 
 import { EditorState, Plugin } from "prosemirror-state";
@@ -166,7 +169,7 @@ describe.each(groupingBlockClasses)(
 // ============================================================
 
 describe("student_hidden typeguards", () => {
-  test("existing typeguards do not match a StudentHiddenBlock", () => {
+  test("isStudentHiddenBlock identifies correctly", () => {
     const block = new StudentHiddenBlock(
       "",
       { from: 0, to: 0 },
@@ -175,6 +178,7 @@ describe("student_hidden typeguards", () => {
       [],
     );
     expect(block.type).toBe(BLOCK_NAME.STUDENT_HIDDEN);
+    expect(isStudentHiddenBlock(block)).toBe(true);
     expect(isContainerBlock(block)).toBe(false);
     expect(isInputAreaBlock(block)).toBe(false);
     expect(isHintBlock(block)).toBe(false);
@@ -182,6 +186,11 @@ describe("student_hidden typeguards", () => {
     expect(isMarkdownBlock(block)).toBe(false);
     expect(isMathDisplayBlock(block)).toBe(false);
     expect(isNewlineBlock(block)).toBe(false);
+  });
+
+  test("isStudentHiddenBlock rejects other block types", () => {
+    const md = new MarkdownBlock("", { from: 0, to: 0 }, { from: 0, to: 0 }, 0);
+    expect(isStudentHiddenBlock(md)).toBe(false);
   });
 });
 
@@ -315,27 +324,53 @@ describe("student_hidden mapping", () => {
 // ============================================================
 
 describe("student_hidden serialization", () => {
-  // KNOWN GAP: the serializer has no case for student_hidden nodes yet, so
-  // serializing a document that contains one throws. This will be fixed
-  // separately — when student_hidden serialization is implemented, replace
-  // this test with one asserting the proper round-trip output.
-  test("serializing a student_hidden node currently throws SerializationError", () => {
+  // The default configuration uses <student-hidden> tags, so the expected
+  // output is the string content wrapped in those tags.
+  test.each(groupingChildCases())(
+    "serialize student_hidden with $child",
+    ({ stringContent, range, innerRange, innerBlocks }) => {
+      const block = new StudentHiddenBlock(
+        stringContent,
+        range,
+        innerRange,
+        0,
+        innerBlocks,
+      );
+      expect(serializeBlocks([block], serializer)).toBe(
+        `<student-hidden>${stringContent}</student-hidden>`,
+      );
+    },
+  );
+
+  test("serialize student_hidden with Lean-style tags", () => {
+    // Mirrors the tag configuration used for Lean in waterproof-vscode.
+    const leanStyleConfig: TagConfiguration = {
+      ...config,
+      studentHidden: {
+        openTag: ":::studentHidden\n",
+        closeTag: "\n:::",
+        openRequiresNewline: true,
+        closeRequiresNewline: true,
+      },
+    };
+    const leanStyleSerializer = new DefaultTagSerializer(leanStyleConfig);
+
     const block = new StudentHiddenBlock(
-      "Some text",
-      { from: 0, to: 28 },
-      { from: 14, to: 23 },
+      "```lean4\ndef x := 1\n```",
+      { from: 0, to: 44 },
+      { from: 17, to: 40 },
       0,
       [
-        new MarkdownBlock(
-          "Some text",
-          { from: 14, to: 23 },
-          { from: 14, to: 23 },
+        new CodeBlock(
+          "def x := 1",
+          { from: 17, to: 40 },
+          { from: 26, to: 36 },
           0,
         ),
       ],
     );
-    expect(() => serializeBlocks([block], serializer)).toThrow(
-      SerializationError,
+    expect(serializeBlocks([block], leanStyleSerializer)).toBe(
+      ":::studentHidden\n```lean4\ndef x := 1\n```\n:::",
     );
   });
 });
@@ -459,5 +494,93 @@ describe("student_hidden plugin decorations", () => {
     // sh2 starts after sh1 and the newline (nodeSize 1).
     expect(decos[1].from).toBe(sh1.nodeSize + 1);
     expect(decos[1].to).toBe(sh1.nodeSize + 1 + sh2.nodeSize);
+  });
+});
+
+// ============================================================
+// Command tests
+// ============================================================
+
+describe("wrapInStudentHidden command", () => {
+  function makeStateWithMarkdown(): EditorState {
+    const mdNode = WaterproofSchema.nodes.markdown.create(
+      {},
+      WaterproofSchema.text("hello"),
+    );
+    const doc = WaterproofSchema.nodes.doc.create({}, mdNode);
+    return stateWithNodeSelAt(doc, 0);
+  }
+
+  test("wraps selected node in a student_hidden node", () => {
+    const state = makeStateWithMarkdown();
+    const newState = applyCommand(state, wrapInStudentHidden(config));
+
+    expect(newState).not.toBeNull();
+    const doc = newState!.doc;
+    expect(doc.firstChild!.type.name).toBe("student_hidden");
+    expect(doc.firstChild!.firstChild!.type.name).toBe("markdown");
+  });
+
+  test("dry-run (no dispatch) returns true when node is selected", () => {
+    const state = makeStateWithMarkdown();
+    expect(wrapInStudentHidden(config)(state, undefined)).toBe(true);
+  });
+
+  test("returns false when selected node is a container", () => {
+    const mdNode = WaterproofSchema.nodes.markdown.create(
+      {},
+      WaterproofSchema.text("hello"),
+    );
+    const cgNode = WaterproofSchema.nodes.container.create(
+      { name: "test" },
+      mdNode,
+    );
+    const doc = WaterproofSchema.nodes.doc.create({}, cgNode);
+    const state = stateWithNodeSelAt(doc, 0);
+    expect(wrapInStudentHidden(config)(state, undefined)).toBe(false);
+  });
+
+  test("returns false when selected node is already student_hidden", () => {
+    const mdNode = WaterproofSchema.nodes.markdown.create(
+      {},
+      WaterproofSchema.text("hello"),
+    );
+    const shNode = WaterproofSchema.nodes.student_hidden.create({}, mdNode);
+    const doc = WaterproofSchema.nodes.doc.create({}, shNode);
+    const state = stateWithNodeSelAt(doc, 0);
+    expect(wrapInStudentHidden(config)(state, undefined)).toBe(false);
+  });
+
+  test("returns false for a node inside a container (student_hidden is doc-level only)", () => {
+    const mdNode = WaterproofSchema.nodes.markdown.create(
+      {},
+      WaterproofSchema.text("hello"),
+    );
+    const cgNode = WaterproofSchema.nodes.container.create(
+      { name: "test" },
+      mdNode,
+    );
+    const doc = WaterproofSchema.nodes.doc.create({}, cgNode);
+    // Select the markdown node inside the container (pos 1).
+    const state = stateWithNodeSelAt(doc, 1);
+    expect(wrapInStudentHidden(config)(state, undefined)).toBe(false);
+  });
+});
+
+describe("wpLift from student_hidden", () => {
+  test("lifts child out of student_hidden", () => {
+    const mdNode = WaterproofSchema.nodes.markdown.create(
+      {},
+      WaterproofSchema.text("hello"),
+    );
+    const shNode = WaterproofSchema.nodes.student_hidden.create({}, mdNode);
+    const doc = WaterproofSchema.nodes.doc.create({}, shNode);
+    const state = stateWithNodeSelAt(doc, 0);
+
+    const newState = applyCommand(state, wpLift(config));
+
+    expect(newState).not.toBeNull();
+    // After lifting, the markdown should be at doc level (no wrapper left)
+    expect(newState!.doc.firstChild!.type.name).toBe("markdown");
   });
 });

--- a/__tests__/student-hidden.test.ts
+++ b/__tests__/student-hidden.test.ts
@@ -45,20 +45,65 @@ const config = configuration("lean4");
 const serializer = new DefaultTagSerializer(config);
 
 // ============================================================
-// Parsing tests — like container, the .mv parser (statemachine.ts)
-// does not produce student_hidden blocks; parsing is handled in
-// waterproof-vscode.
+// Parsing tests — the .mv parser (statemachine.ts) recognizes
+// <student-hidden> ... </student-hidden> tags.
 // ============================================================
 
-describe("student_hidden parsing (not supported by .mv parser)", () => {
-  test("parser never produces student_hidden blocks", () => {
-    const doc = `<student-hidden>
-Some markdown content
-</student-hidden>`;
+describe("student_hidden parsing (.mv)", () => {
+  test("parses <student-hidden> into a StudentHiddenBlock", () => {
+    const doc = "<student-hidden>Some text</student-hidden>";
     const blocks = parse(doc, { language: "lean4" });
-    expect(blocks.every((b) => b.type !== BLOCK_NAME.STUDENT_HIDDEN)).toBe(
-      true,
-    );
+
+    expect(blocks).toHaveLength(1);
+    const block = blocks[0];
+    expect(isStudentHiddenBlock(block)).toBe(true);
+    expect(block.stringContent).toBe("Some text");
+    expect(block.range).toEqual({ from: 0, to: doc.length });
+    expect(block.innerRange).toEqual({ from: 16, to: 25 });
+    expect(block.innerBlocks).toHaveLength(1);
+    expect(isMarkdownBlock(block.innerBlocks![0])).toBe(true);
+    expect(block.innerBlocks![0].stringContent).toBe("Some text");
+  });
+
+  test("parses code inside a student-hidden block", () => {
+    const doc =
+      "<student-hidden>\n```lean4\nsecret code\n```\n</student-hidden>";
+    const blocks = parse(doc, { language: "lean4" });
+
+    expect(blocks).toHaveLength(1);
+    const block = blocks[0];
+    expect(isStudentHiddenBlock(block)).toBe(true);
+    const inner = block.innerBlocks!;
+    expect(inner.map((b) => b.type)).toEqual([
+      BLOCK_NAME.NEWLINE,
+      BLOCK_NAME.CODE,
+      BLOCK_NAME.NEWLINE,
+    ]);
+    expect(inner[1].stringContent).toBe("secret code");
+  });
+
+  test("round-trip: parse then serialize is the identity", () => {
+    const doc =
+      "Intro\n<student-hidden>\n```lean4\nsecret code\n```\n</student-hidden>\nAfter";
+    const blocks = parse(doc, { language: "lean4" });
+    expect(blocks.some((b) => isStudentHiddenBlock(b))).toBe(true);
+    expect(serializeBlocks(blocks, serializer)).toBe(doc);
+  });
+
+  test("nested tags inside student-hidden are not recognized (flat nesting)", () => {
+    // The .mv state machine only supports one level of nesting, so an input
+    // area inside a student-hidden block stays plain markdown. Round-tripping
+    // still preserves the document.
+    const doc = "<student-hidden><input-area>x</input-area></student-hidden>";
+    const blocks = parse(doc, { language: "lean4" });
+
+    expect(blocks).toHaveLength(1);
+    const block = blocks[0];
+    expect(isStudentHiddenBlock(block)).toBe(true);
+    expect(block.innerBlocks!.map((b) => b.type)).toEqual([
+      BLOCK_NAME.MARKDOWN,
+    ]);
+    expect(serializeBlocks(blocks, serializer)).toBe(doc);
   });
 });
 

--- a/__tests__/student-hidden.test.ts
+++ b/__tests__/student-hidden.test.ts
@@ -1,0 +1,463 @@
+// LLM-generated unit tests that might codify existing bugs
+
+import { parse } from "../src/markdown-defaults";
+import {
+  isMarkdownBlock,
+  isCodeBlock,
+  isHintBlock,
+  isInputAreaBlock,
+  isMathDisplayBlock,
+  isNewlineBlock,
+  isContainerBlock,
+} from "../src/document/blocks";
+import {
+  Block,
+  BlockRange,
+  ContainerBlock,
+  MarkdownBlock,
+  StudentHiddenBlock,
+  constructDocument,
+} from "../src/document";
+import { BLOCK_NAME } from "../src/document/blocks/block";
+import { configuration } from "../src/markdown-defaults";
+import {
+  DefaultTagSerializer,
+  SerializationError,
+} from "../src/serialization/DocumentSerializer";
+import { sanityCheckTree } from "./mapping/util";
+import {
+  createTestMapping,
+  groupingChildCases,
+  serializeBlocks,
+} from "./helpers";
+
+import { EditorState, Plugin } from "prosemirror-state";
+import { Node as PNode } from "prosemirror-model";
+import { DecorationSet } from "prosemirror-view";
+import { WaterproofSchema } from "../src/schema";
+import { studentHiddenPlugin } from "../src/student-hidden";
+import { INPUT_AREA_PLUGIN_KEY, inputAreaPlugin } from "../src/inputArea";
+
+const config = configuration("lean4");
+const serializer = new DefaultTagSerializer(config);
+
+// ============================================================
+// Parsing tests — like container, the .mv parser (statemachine.ts)
+// does not produce student_hidden blocks; parsing is handled in
+// waterproof-vscode.
+// ============================================================
+
+describe("student_hidden parsing (not supported by .mv parser)", () => {
+  test("parser never produces student_hidden blocks", () => {
+    const doc = `<student-hidden>
+Some markdown content
+</student-hidden>`;
+    const blocks = parse(doc, { language: "lean4" });
+    expect(blocks.every((b) => b.type !== BLOCK_NAME.STUDENT_HIDDEN)).toBe(
+      true,
+    );
+  });
+});
+
+// ============================================================
+// Block construction tests, parametrized over both grouping
+// block classes (ContainerBlock and StudentHiddenBlock) since
+// they share the same constructor contract.
+// ============================================================
+
+type ChildBlocksArg =
+  | Block[]
+  | ((
+      innerContent: string,
+      innerRange: BlockRange,
+      lineStartOffset: number,
+    ) => Block[]);
+
+const groupingBlockClasses = [
+  {
+    blockClass: "ContainerBlock",
+    nodeName: "container",
+    make: (
+      stringContent: string,
+      range: BlockRange,
+      innerRange: BlockRange,
+      lineStart: number,
+      childBlocks: ChildBlocksArg,
+    ): Block =>
+      new ContainerBlock(
+        stringContent,
+        "test",
+        range,
+        innerRange,
+        lineStart,
+        childBlocks,
+      ),
+  },
+  {
+    blockClass: "StudentHiddenBlock",
+    nodeName: "student_hidden",
+    make: (
+      stringContent: string,
+      range: BlockRange,
+      innerRange: BlockRange,
+      lineStart: number,
+      childBlocks: ChildBlocksArg,
+    ): Block =>
+      new StudentHiddenBlock(
+        stringContent,
+        range,
+        innerRange,
+        lineStart,
+        childBlocks,
+      ),
+  },
+];
+
+describe.each(groupingBlockClasses)(
+  "$blockClass construction",
+  ({ nodeName, make }) => {
+    test("constructor accepts an array of child blocks", () => {
+      const child = new MarkdownBlock(
+        "text",
+        { from: 14, to: 18 },
+        { from: 14, to: 18 },
+        0,
+      );
+      const block = make("text", { from: 0, to: 23 }, { from: 14, to: 18 }, 0, [
+        child,
+      ]);
+      expect(block.innerBlocks).toEqual([child]);
+    });
+
+    test("constructor accepts a child block factory function", () => {
+      const innerRange = { from: 14, to: 18 };
+      const factory = jest.fn(
+        (innerContent: string, range: BlockRange, lineStartOffset: number) => [
+          new MarkdownBlock(innerContent, range, range, lineStartOffset),
+        ],
+      );
+      const block = make("text", { from: 0, to: 23 }, innerRange, 3, factory);
+
+      // The factory receives the block's content, inner range and line start.
+      expect(factory).toHaveBeenCalledWith("text", innerRange, 3);
+      expect(block.innerBlocks).toHaveLength(1);
+      expect(block.innerBlocks![0].stringContent).toBe("text");
+    });
+
+    test(`toProseMirror creates a ${nodeName} node containing the children`, () => {
+      const block = make("text", { from: 0, to: 23 }, { from: 14, to: 18 }, 0, [
+        new MarkdownBlock(
+          "text",
+          { from: 14, to: 18 },
+          { from: 14, to: 18 },
+          0,
+        ),
+      ]);
+      const node = block.toProseMirror();
+      expect(node.type.name).toBe(nodeName);
+      expect(node.content.childCount).toBe(1);
+      expect(node.content.firstChild!.type.name).toBe("markdown");
+    });
+  },
+);
+
+// ============================================================
+// Typeguard tests
+// ============================================================
+
+describe("student_hidden typeguards", () => {
+  test("existing typeguards do not match a StudentHiddenBlock", () => {
+    const block = new StudentHiddenBlock(
+      "",
+      { from: 0, to: 0 },
+      { from: 0, to: 0 },
+      0,
+      [],
+    );
+    expect(block.type).toBe(BLOCK_NAME.STUDENT_HIDDEN);
+    expect(isContainerBlock(block)).toBe(false);
+    expect(isInputAreaBlock(block)).toBe(false);
+    expect(isHintBlock(block)).toBe(false);
+    expect(isCodeBlock(block)).toBe(false);
+    expect(isMarkdownBlock(block)).toBe(false);
+    expect(isMathDisplayBlock(block)).toBe(false);
+    expect(isNewlineBlock(block)).toBe(false);
+  });
+});
+
+// ============================================================
+// ProseMirror document construction tests
+// ============================================================
+
+describe("student_hidden ProseMirror construction", () => {
+  test.each(groupingChildCases())(
+    "constructDocument with student_hidden containing $child",
+    ({ stringContent, range, innerRange, innerBlocks }) => {
+      const block = new StudentHiddenBlock(
+        stringContent,
+        range,
+        innerRange,
+        0,
+        innerBlocks,
+      );
+      const doc = constructDocument([block]);
+
+      expect(doc.type.name).toBe("doc");
+      expect(doc.content.childCount).toBe(1);
+      const shNode = doc.content.firstChild!;
+      expect(shNode.type.name).toBe("student_hidden");
+
+      // The child node types mirror the child block types.
+      const childTypes: string[] = [];
+      shNode.content.forEach((child) => childTypes.push(child.type.name));
+      expect(childTypes).toEqual(innerBlocks.map((b) => b.type));
+    },
+  );
+});
+
+// ============================================================
+// Schema tests
+// ============================================================
+
+describe("student_hidden schema", () => {
+  const markdownNode = () =>
+    WaterproofSchema.nodes.markdown.create({}, WaterproofSchema.text("text"));
+
+  test("student_hidden requires at least one child", () => {
+    expect(() =>
+      WaterproofSchema.nodes.student_hidden.createChecked({}, []),
+    ).toThrow();
+  });
+
+  test("student_hidden cannot be nested inside student_hidden", () => {
+    const inner = WaterproofSchema.nodes.student_hidden.createChecked(
+      {},
+      markdownNode(),
+    );
+    expect(() =>
+      WaterproofSchema.nodes.student_hidden.createChecked({}, inner),
+    ).toThrow();
+  });
+
+  test("student_hidden cannot be nested inside a container", () => {
+    const inner = WaterproofSchema.nodes.student_hidden.createChecked(
+      {},
+      markdownNode(),
+    );
+    expect(() =>
+      WaterproofSchema.nodes.container.createChecked({ name: "test" }, inner),
+    ).toThrow();
+  });
+
+  test("student_hidden is allowed at document level", () => {
+    const shNode = WaterproofSchema.nodes.student_hidden.createChecked(
+      {},
+      markdownNode(),
+    );
+    const doc = WaterproofSchema.nodes.doc.createChecked({}, shNode);
+    expect(doc.firstChild!.type.name).toBe("student_hidden");
+  });
+
+  test("student_hidden accepts all containercontent children", () => {
+    const children = [
+      markdownNode(),
+      WaterproofSchema.nodes.newline.create(),
+      WaterproofSchema.nodes.code.create({}, WaterproofSchema.text("code")),
+      WaterproofSchema.nodes.math_display.create(
+        {},
+        WaterproofSchema.text("x^2"),
+      ),
+      WaterproofSchema.nodes.input.createChecked({}, markdownNode()),
+      WaterproofSchema.nodes.hint.createChecked(
+        { title: "Hint" },
+        markdownNode(),
+      ),
+    ];
+    const shNode = WaterproofSchema.nodes.student_hidden.createChecked(
+      {},
+      children,
+    );
+    expect(shNode.content.childCount).toBe(children.length);
+  });
+});
+
+// ============================================================
+// Mapping tests
+// ============================================================
+
+describe("student_hidden mapping", () => {
+  test.each(groupingChildCases())(
+    "mapping with student_hidden containing $child",
+    ({ stringContent, range, innerRange, innerBlocks }) => {
+      const block = new StudentHiddenBlock(
+        stringContent,
+        range,
+        innerRange,
+        0,
+        innerBlocks,
+      );
+      const tree = createTestMapping([block], config, serializer);
+
+      expect(tree.root.children.length).toBe(1);
+      const shNode = tree.root.children[0];
+      expect(shNode.type).toBe("student_hidden");
+      expect(shNode.children.map((c) => c.type)).toEqual(
+        innerBlocks.map((b) => b.type),
+      );
+
+      sanityCheckTree(tree.root);
+    },
+  );
+});
+
+// ============================================================
+// Serialization tests
+// ============================================================
+
+describe("student_hidden serialization", () => {
+  // KNOWN GAP: the serializer has no case for student_hidden nodes yet, so
+  // serializing a document that contains one throws. This will be fixed
+  // separately — when student_hidden serialization is implemented, replace
+  // this test with one asserting the proper round-trip output.
+  test("serializing a student_hidden node currently throws SerializationError", () => {
+    const block = new StudentHiddenBlock(
+      "Some text",
+      { from: 0, to: 28 },
+      { from: 14, to: 23 },
+      0,
+      [
+        new MarkdownBlock(
+          "Some text",
+          { from: 14, to: 23 },
+          { from: 14, to: 23 },
+          0,
+        ),
+      ],
+    );
+    expect(() => serializeBlocks([block], serializer)).toThrow(
+      SerializationError,
+    );
+  });
+});
+
+// ============================================================
+// Plugin (decoration) tests
+// ============================================================
+
+describe("student_hidden plugin decorations", () => {
+  /** Creates a student_hidden node containing a single markdown child. */
+  function studentHiddenNode(text = "secret"): PNode {
+    return WaterproofSchema.nodes.student_hidden.create(
+      {},
+      WaterproofSchema.nodes.markdown.create({}, WaterproofSchema.text(text)),
+    );
+  }
+
+  function makeState(
+    doc: PNode,
+    plugins: Plugin[] = [inputAreaPlugin, studentHiddenPlugin],
+  ): EditorState {
+    return EditorState.create({ schema: WaterproofSchema, doc, plugins });
+  }
+
+  /** Invokes the plugin's decorations prop on `state` and returns the decorations. */
+  function getDecorations(state: EditorState) {
+    const decoProp = studentHiddenPlugin.props.decorations!;
+    const decoSet = decoProp.call(studentHiddenPlugin, state) as DecorationSet;
+    return decoSet.find();
+  }
+
+  /** Extracts the class attribute of a node decoration (internal API). */
+  function decoClass(deco: ReturnType<typeof getDecorations>[number]): string {
+    return (deco as unknown as { type: { attrs: { class: string } } }).type
+      .attrs.class;
+  }
+
+  function setTeacherMode(state: EditorState, teacher: boolean): EditorState {
+    return state.apply(state.tr.setMeta(INPUT_AREA_PLUGIN_KEY, { teacher }));
+  }
+
+  test("student mode (default): node is decorated with student-hidden-student", () => {
+    const shNode = studentHiddenNode();
+    const doc = WaterproofSchema.nodes.doc.create({}, [
+      shNode,
+      WaterproofSchema.nodes.newline.create(),
+    ]);
+    const decos = getDecorations(makeState(doc));
+
+    expect(decos).toHaveLength(1);
+    expect(decoClass(decos[0])).toBe("student-hidden-student");
+    // The decoration spans the entire student_hidden node.
+    expect(decos[0].from).toBe(0);
+    expect(decos[0].to).toBe(shNode.nodeSize);
+  });
+
+  test("teacher mode: node is decorated with student-hidden-teacher", () => {
+    const doc = WaterproofSchema.nodes.doc.create({}, [studentHiddenNode()]);
+    const state = setTeacherMode(makeState(doc), true);
+    const decos = getDecorations(state);
+
+    expect(decos).toHaveLength(1);
+    expect(decoClass(decos[0])).toBe("student-hidden-teacher");
+  });
+
+  test("toggling teacher mode off restores the student decoration", () => {
+    const doc = WaterproofSchema.nodes.doc.create({}, [studentHiddenNode()]);
+    let state = makeState(doc);
+    state = setTeacherMode(state, true);
+    state = setTeacherMode(state, false);
+    const decos = getDecorations(state);
+
+    expect(decos).toHaveLength(1);
+    expect(decoClass(decos[0])).toBe("student-hidden-student");
+  });
+
+  test("without the input area plugin, defaults to student mode", () => {
+    const doc = WaterproofSchema.nodes.doc.create({}, [studentHiddenNode()]);
+    const state = makeState(doc, [studentHiddenPlugin]);
+    const decos = getDecorations(state);
+
+    expect(decos).toHaveLength(1);
+    expect(decoClass(decos[0])).toBe("student-hidden-student");
+  });
+
+  test("documents without student_hidden nodes get no decorations", () => {
+    const doc = WaterproofSchema.nodes.doc.create({}, [
+      WaterproofSchema.nodes.markdown.create(
+        {},
+        WaterproofSchema.text("visible"),
+      ),
+    ]);
+    expect(getDecorations(makeState(doc))).toHaveLength(0);
+  });
+
+  test("only the student_hidden node itself is decorated, not its children", () => {
+    const shNode = WaterproofSchema.nodes.student_hidden.create({}, [
+      WaterproofSchema.nodes.markdown.create({}, WaterproofSchema.text("a")),
+      WaterproofSchema.nodes.newline.create(),
+      WaterproofSchema.nodes.code.create({}, WaterproofSchema.text("b")),
+    ]);
+    const doc = WaterproofSchema.nodes.doc.create({}, [shNode]);
+    const decos = getDecorations(makeState(doc));
+
+    expect(decos).toHaveLength(1);
+  });
+
+  test("every student_hidden node in the document is decorated", () => {
+    const sh1 = studentHiddenNode("one");
+    const sh2 = studentHiddenNode("two");
+    const doc = WaterproofSchema.nodes.doc.create({}, [
+      sh1,
+      WaterproofSchema.nodes.newline.create(),
+      sh2,
+    ]);
+    const decos = getDecorations(makeState(doc));
+
+    expect(decos).toHaveLength(2);
+    expect(decos[0].from).toBe(0);
+    expect(decos[0].to).toBe(sh1.nodeSize);
+    // sh2 starts after sh1 and the newline (nodeSize 1).
+    expect(decos[1].from).toBe(sh1.nodeSize + 1);
+    expect(decos[1].to).toBe(sh1.nodeSize + 1 + sh2.nodeSize);
+  });
+});

--- a/__tests__/student-hidden.test.ts
+++ b/__tests__/student-hidden.test.ts
@@ -14,6 +14,7 @@ import {
 import {
   Block,
   BlockRange,
+  ChildBlocks,
   CodeBlock,
   ContainerBlock,
   MarkdownBlock,
@@ -113,14 +114,6 @@ describe("student_hidden parsing (.mv)", () => {
 // they share the same constructor contract.
 // ============================================================
 
-type ChildBlocksArg =
-  | Block[]
-  | ((
-      innerContent: string,
-      innerRange: BlockRange,
-      lineStartOffset: number,
-    ) => Block[]);
-
 const groupingBlockClasses = [
   {
     blockClass: "ContainerBlock",
@@ -130,7 +123,7 @@ const groupingBlockClasses = [
       range: BlockRange,
       innerRange: BlockRange,
       lineStart: number,
-      childBlocks: ChildBlocksArg,
+      childBlocks: ChildBlocks,
     ): Block =>
       new ContainerBlock(
         stringContent,
@@ -149,7 +142,7 @@ const groupingBlockClasses = [
       range: BlockRange,
       innerRange: BlockRange,
       lineStart: number,
-      childBlocks: ChildBlocksArg,
+      childBlocks: ChildBlocks,
     ): Block =>
       new StudentHiddenBlock(
         stringContent,

--- a/__tests__/student-hidden.test.ts
+++ b/__tests__/student-hidden.test.ts
@@ -345,7 +345,7 @@ describe("student_hidden mapping", () => {
       );
       const tree = createTestMapping([block], config, serializer);
 
-      expect(tree.root.children.length).toBe(1);
+      expect(tree.root.children).toHaveLength(1);
       const shNode = tree.root.children[0];
       expect(shNode.type).toBe("student_hidden");
       expect(shNode.children.map((c) => c.type)).toEqual(

--- a/package-lock.json
+++ b/package-lock.json
@@ -2823,6 +2823,23 @@
         "typescript": ">=4.8.4 <5.9.0"
       }
     },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
@@ -3119,13 +3136,6 @@
         "@babel/core": "^7.0.0"
       }
     },
-    "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.38",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.38.tgz",
@@ -3137,16 +3147,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/braces": {
@@ -5598,9 +5598,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.1.tgz",
+      "integrity": "sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==",
       "dev": true,
       "funding": [
         {
@@ -5617,7 +5617,7 @@
         "argparse": "^2.0.1"
       },
       "bin": {
-        "js-yaml": "bin/js-yaml.js"
+        "js-yaml": "bin/js-yaml.mjs"
       }
     },
     "node_modules/jsdom": {
@@ -5798,9 +5798,9 @@
       "license": "MIT"
     },
     "node_modules/linkify-it": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
-      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
       "funding": [
         {
           "type": "github",
@@ -5997,10 +5997,17 @@
         "node": "*"
       }
     },
+    "node_modules/minimatch/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6063,6 +6070,23 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/mocha/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mocha/node_modules/brace-expansion": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/mocha/node_modules/glob": {

--- a/package.json
+++ b/package.json
@@ -84,10 +84,7 @@
       "serialize-javascript": "7.0.5",
       "diff": "8.0.3"
     },
-    "eslint": {
-      "brace-expansion": "2.1.0"
-    },
-    "js-yaml": "4.2.0"
+    "js-yaml": "5.2.1"
   },
   "peerDependencies": {
     "@codemirror/autocomplete": "6.18.1",

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -95,6 +95,7 @@ export type TagConfiguration = {
     openTag: (name: string) => string;
     closeTag: string;
   } & RequiresNewline;
+  studentHidden: OpenCloseTag & RequiresNewline;
 };
 
 export class NodeUpdateError extends Error {

--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -36,9 +36,10 @@ export function wpLift(_tagConf: TagConfiguration): Command {
     if (
       type !== WaterproofSchema.nodes.hint &&
       type !== WaterproofSchema.nodes.input &&
-      type !== WaterproofSchema.nodes.container
+      type !== WaterproofSchema.nodes.container &&
+      type !== WaterproofSchema.nodes.student_hidden
     ) {
-      // We can only lift hint, input area, or container nodes.
+      // We can only lift hint, input area, container, or student-hidden nodes.
       return false;
     }
 
@@ -253,6 +254,25 @@ export function wrapInContainer(
   return (state, dispatch) => {
     if (!preWrapCheck(state, [WaterproofSchema.nodes.container])) return false;
     return wpWrapIn(WaterproofSchema.nodes.container, tagConf, { name })(
+      state,
+      dispatch,
+    );
+  };
+}
+
+export function wrapInStudentHidden(tagConf: TagConfiguration): Command {
+  return (state, dispatch) => {
+    // student_hidden only accepts containercontent (which excludes container
+    // and student_hidden itself) and is only valid at document level, so both
+    // types are disallowed as target, ancestor, and descendant.
+    if (
+      !preWrapCheck(state, [
+        WaterproofSchema.nodes.container,
+        WaterproofSchema.nodes.student_hidden,
+      ])
+    )
+      return false;
+    return wpWrapIn(WaterproofSchema.nodes.student_hidden, tagConf)(
       state,
       dispatch,
     );

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -4,6 +4,7 @@ export {
   wrapInHint,
   wrapInInput,
   wrapInContainer,
+  wrapInStudentHidden,
   deleteSelection,
 } from "./commands";
 export { InsertionPlace } from "./types";

--- a/src/commands/utils.ts
+++ b/src/commands/utils.ts
@@ -41,6 +41,8 @@ function tagConfForNodeType(nodeType: NodeType, tagConf: TagConfiguration) {
   if (nodeType === WaterproofSchema.nodes.markdown) return tagConf.markdown;
   if (nodeType === WaterproofSchema.nodes.math_display) return tagConf.math;
   if (nodeType === WaterproofSchema.nodes.container) return tagConf.container;
+  if (nodeType === WaterproofSchema.nodes.student_hidden)
+    return tagConf.studentHidden;
   return null;
 }
 

--- a/src/document/blocks/block.ts
+++ b/src/document/blocks/block.ts
@@ -9,6 +9,7 @@ export enum BLOCK_NAME {
   CODE = "code",
   NEWLINE = "newline",
   CONTAINER = "container",
+  STUDENT_HIDDEN = "student_hidden",
 }
 
 export interface BlockRange {

--- a/src/document/blocks/blocktypes.ts
+++ b/src/document/blocks/blocktypes.ts
@@ -277,7 +277,7 @@ export class ContainerBlock implements Block {
 }
 
 /**
- * The `StudentHintBlock` acts similar to the {@linkcode ContainerBlock} in the
+ * The `StudentHiddenBlock` acts similar to the {@linkcode ContainerBlock} in the
  * sense that it groups child blocks together.
  *
  * The child blocks are only shown when in teacher mode and hence never visible

--- a/src/document/blocks/blocktypes.ts
+++ b/src/document/blocks/blocktypes.ts
@@ -9,6 +9,7 @@ import {
   markdown,
   mathDisplay,
   newline,
+  studentHidden,
 } from "./schema";
 
 const indentation = (level: number): string => "  ".repeat(level);
@@ -269,6 +270,51 @@ export class ContainerBlock implements Block {
   debugPrint(level: number): void {
     console.log(
       `${indentation(level)}ContainerBlock(${this.name}) {${debugInfo(this)}} [`,
+    );
+    this.innerBlocks.forEach((block) => block.debugPrint(level + 1));
+    console.log(`${indentation(level)}]`);
+  }
+}
+
+/**
+ * The `StudentHintBlock` acts similar to the {@linkcode ContainerBlock} in the
+ * sense that it groups child blocks together.
+ *
+ * The child blocks are only shown when in teacher mode and hence never visible
+ * to students.
+ */
+export class StudentHiddenBlock implements Block {
+  public type = BLOCK_NAME.STUDENT_HIDDEN;
+  public innerBlocks: Block[];
+
+  constructor(
+    public stringContent: string,
+    public range: BlockRange,
+    public innerRange: BlockRange,
+    public lineStart: number,
+    childBlocks:
+      | Block[]
+      | ((
+          innerContent: string,
+          innerRange: BlockRange,
+          lineStartOffset: number,
+        ) => Block[]),
+  ) {
+    if (typeof childBlocks === "function") {
+      this.innerBlocks = childBlocks(stringContent, innerRange, lineStart);
+    } else {
+      this.innerBlocks = childBlocks;
+    }
+  }
+
+  toProseMirror() {
+    const childNodes = this.innerBlocks.map((block) => block.toProseMirror());
+    return studentHidden(childNodes);
+  }
+
+  debugPrint(level: number): void {
+    console.log(
+      `${indentation(level)}StudentHiddenBlock {${debugInfo(this)}} [`,
     );
     this.innerBlocks.forEach((block) => block.debugPrint(level + 1));
     console.log(`${indentation(level)}]`);

--- a/src/document/blocks/blocktypes.ts
+++ b/src/document/blocks/blocktypes.ts
@@ -17,32 +17,37 @@ const debugInfo = (block: Block): string =>
   `{range=${block.range.from}-${block.range.to}}`;
 
 /**
- * InputAreaBlocks are the parts of the document that should be editable by students.
- * Every input area has an accompanying status to indicate whether the input area is 'correct'.
+ * The child blocks of a grouping block: either an array of blocks, or a
+ * function that constructs the child blocks given the inner content, inner
+ * range, and line start.
  */
-export class InputAreaBlock implements Block {
-  public type = BLOCK_NAME.INPUT_AREA;
+export type ChildBlocks =
+  | Block[]
+  | ((
+      innerContent: string,
+      innerRange: BlockRange,
+      lineStartOffset: number,
+    ) => Block[]);
+
+/**
+ * Base class for blocks that group child blocks together (input areas, hints,
+ * containers, and student-hidden blocks).
+ *
+ * @param stringContent Content of the block
+ * @param range The range (from position to to position in the original document) of the entire block, including its tags.
+ * @param innerRange The range (from position to to position in the original document) of the inner content of the block, excluding its tags.
+ * @param childBlocks Either an array of child blocks of this block, or a function that constructs the child blocks given the inner range and content.
+ */
+export abstract class GroupingBlock implements Block {
+  abstract type: BLOCK_NAME;
   public innerBlocks: Block[];
 
-  /**
-   * Construct a new InputAreaBlock.
-   * @param stringContent Content of the input area
-   * @param range The range (from position to to position in the original document) of the entire input area block, including the its tags.
-   * @param innerRange The range (from position to to position in the original document) of the inner content of the input area block, excluding its tags.
-   * @param childBlocks Either an array of child blocks of this input area block, or a function that constructs the child blocks given the inner range and content.
-   */
   constructor(
     public stringContent: string,
     public range: BlockRange,
     public innerRange: BlockRange,
     public lineStart: number,
-    childBlocks:
-      | Block[]
-      | ((
-          innerContent: string,
-          innerRange: BlockRange,
-          lineStartOffset: number,
-        ) => Block[]),
+    childBlocks: ChildBlocks,
   ) {
     if (typeof childBlocks === "function") {
       this.innerBlocks = childBlocks(stringContent, innerRange, lineStart);
@@ -51,16 +56,38 @@ export class InputAreaBlock implements Block {
     }
   }
 
-  toProseMirror() {
+  /** Wrap the given ProseMirror child nodes in this block's node type. */
+  protected abstract wrapChildNodes(childNodes: Node[]): Node;
+
+  toProseMirror(): Node {
     const childNodes = this.innerBlocks.map((block) => block.toProseMirror());
-    return inputArea(childNodes);
+    return this.wrapChildNodes(childNodes);
   }
+
+  /** The part of the debug print line before the child block listing. */
+  protected abstract debugHeader(): string;
 
   // Debug print function. // FIXME: Maybe remove?
   debugPrint(level: number): void {
-    console.log(`${indentation(level)}InputAreaBlock {${debugInfo(this)}} [`);
+    console.log(`${indentation(level)}${this.debugHeader()} [`);
     this.innerBlocks.forEach((block) => block.debugPrint(level + 1));
     console.log(`${indentation(level)}]`);
+  }
+}
+
+/**
+ * InputAreaBlocks are the parts of the document that should be editable by students.
+ * Every input area has an accompanying status to indicate whether the input area is 'correct'.
+ */
+export class InputAreaBlock extends GroupingBlock {
+  public type = BLOCK_NAME.INPUT_AREA;
+
+  protected wrapChildNodes(childNodes: Node[]): Node {
+    return inputArea(childNodes);
+  }
+
+  protected debugHeader(): string {
+    return `InputAreaBlock {${debugInfo(this)}}`;
   }
 }
 
@@ -68,52 +95,33 @@ export class InputAreaBlock implements Block {
  * HintBlocks are foldable blocks that can be used to hide parts of the document by default.
  * Useful for giving hints to students or hiding import/configuration statements from the student.
  */
-export class HintBlock implements Block {
+export class HintBlock extends GroupingBlock {
   public type = BLOCK_NAME.HINT;
-  public innerBlocks: Block[];
 
   /**
    * Construct a new HintBlock.
-   * @param stringContent Content of the hint block
    * @param title Title of the hint block (the part that is displayed in the document when folded)
-   * @param range The range (from position to to position in the original document) of the entire hint block, including its tags.
-   * @param innerRange The range (from position to to position in the original document) of the inner content of the hint block, excluding its tags.
-   * @param childBlocks Either an array of child blocks of this hint block, or a function that constructs the child blocks given the inner range and content.
+   *
+   * See {@linkcode GroupingBlock} for the other parameters.
    */
   constructor(
-    public stringContent: string,
+    stringContent: string,
     public title: string,
-    public range: BlockRange,
-    public innerRange: BlockRange,
-    public lineStart: number,
-    childBlocks:
-      | Block[]
-      | ((
-          innerContent: string,
-          innerRange: BlockRange,
-          lineStartOffset: number,
-        ) => Block[]),
+    range: BlockRange,
+    innerRange: BlockRange,
+    lineStart: number,
+    childBlocks: ChildBlocks,
   ) {
-    if (typeof childBlocks === "function") {
-      this.innerBlocks = childBlocks(stringContent, innerRange, lineStart);
-    } else {
-      this.innerBlocks = childBlocks;
-    }
+    super(stringContent, range, innerRange, lineStart, childBlocks);
   }
 
-  toProseMirror() {
+  protected wrapChildNodes(childNodes: Node[]): Node {
     // We need to construct a hint node with a title and inner blocks.
-    const childNodes = this.innerBlocks.map((block) => block.toProseMirror());
     return hint(this.title, childNodes);
   }
 
-  // Debug print function.
-  debugPrint(level: number): void {
-    console.log(
-      `${indentation(level)}HintBlock {${debugInfo(this)}} {title="${this.title}"} [`,
-    );
-    this.innerBlocks.forEach((block) => block.debugPrint(level + 1));
-    console.log(`${indentation(level)}]`);
+  protected debugHeader(): string {
+    return `HintBlock {${debugInfo(this)}} {title="${this.title}"}`;
   }
 }
 
@@ -237,42 +245,32 @@ export class NewlineBlock implements Block {
  * In Lean context, multilean blocks are represented as containers with name "multilean".
  * They can contain both top-level blocks (input, hint) and leaf blocks (math, code, markdown).
  */
-export class ContainerBlock implements Block {
+export class ContainerBlock extends GroupingBlock {
   public type = BLOCK_NAME.CONTAINER;
-  public innerBlocks: Block[];
 
+  /**
+   * Construct a new ContainerBlock.
+   * @param name Name identifying the container type (e.g. "multilean")
+   *
+   * See {@linkcode GroupingBlock} for the other parameters.
+   */
   constructor(
-    public stringContent: string,
+    stringContent: string,
     public name: string,
-    public range: BlockRange,
-    public innerRange: BlockRange,
-    public lineStart: number,
-    childBlocks:
-      | Block[]
-      | ((
-          innerContent: string,
-          innerRange: BlockRange,
-          lineStartOffset: number,
-        ) => Block[]),
+    range: BlockRange,
+    innerRange: BlockRange,
+    lineStart: number,
+    childBlocks: ChildBlocks,
   ) {
-    if (typeof childBlocks === "function") {
-      this.innerBlocks = childBlocks(stringContent, innerRange, lineStart);
-    } else {
-      this.innerBlocks = childBlocks;
-    }
+    super(stringContent, range, innerRange, lineStart, childBlocks);
   }
 
-  toProseMirror() {
-    const childNodes = this.innerBlocks.map((block) => block.toProseMirror());
+  protected wrapChildNodes(childNodes: Node[]): Node {
     return container(this.name, childNodes);
   }
 
-  debugPrint(level: number): void {
-    console.log(
-      `${indentation(level)}ContainerBlock(${this.name}) {${debugInfo(this)}} [`,
-    );
-    this.innerBlocks.forEach((block) => block.debugPrint(level + 1));
-    console.log(`${indentation(level)}]`);
+  protected debugHeader(): string {
+    return `ContainerBlock(${this.name}) {${debugInfo(this)}}`;
   }
 }
 
@@ -283,40 +281,14 @@ export class ContainerBlock implements Block {
  * The child blocks are only shown when in teacher mode and hence never visible
  * to students.
  */
-export class StudentHiddenBlock implements Block {
+export class StudentHiddenBlock extends GroupingBlock {
   public type = BLOCK_NAME.STUDENT_HIDDEN;
-  public innerBlocks: Block[];
 
-  constructor(
-    public stringContent: string,
-    public range: BlockRange,
-    public innerRange: BlockRange,
-    public lineStart: number,
-    childBlocks:
-      | Block[]
-      | ((
-          innerContent: string,
-          innerRange: BlockRange,
-          lineStartOffset: number,
-        ) => Block[]),
-  ) {
-    if (typeof childBlocks === "function") {
-      this.innerBlocks = childBlocks(stringContent, innerRange, lineStart);
-    } else {
-      this.innerBlocks = childBlocks;
-    }
-  }
-
-  toProseMirror() {
-    const childNodes = this.innerBlocks.map((block) => block.toProseMirror());
+  protected wrapChildNodes(childNodes: Node[]): Node {
     return studentHidden(childNodes);
   }
 
-  debugPrint(level: number): void {
-    console.log(
-      `${indentation(level)}StudentHiddenBlock {${debugInfo(this)}} [`,
-    );
-    this.innerBlocks.forEach((block) => block.debugPrint(level + 1));
-    console.log(`${indentation(level)}]`);
+  protected debugHeader(): string {
+    return `StudentHiddenBlock {${debugInfo(this)}}`;
   }
 }

--- a/src/document/blocks/schema.ts
+++ b/src/document/blocks/schema.ts
@@ -40,6 +40,11 @@ export const container = (name: string, childNodes: ProseNode[]): ProseNode => {
   return WaterproofSchema.nodes.container.create({ name }, childNodes);
 };
 
+/** Construct a ProseMirror node of the student-hidden type */
+export const studentHidden = (childNodes: ProseNode[]): ProseNode => {
+  return WaterproofSchema.nodes.student_hidden.create({}, childNodes);
+};
+
 // ##### Special newline block ######
 export const newline = () => {
   return WaterproofSchema.nodes.newline.create();

--- a/src/document/blocks/typeguards.ts
+++ b/src/document/blocks/typeguards.ts
@@ -7,6 +7,7 @@ import {
   MarkdownBlock,
   MathDisplayBlock,
   NewlineBlock,
+  StudentHiddenBlock,
 } from "./blocktypes";
 
 export const isInputAreaBlock = (block: Block): block is InputAreaBlock =>
@@ -23,3 +24,6 @@ export const isNewlineBlock = (block: Block): block is NewlineBlock =>
   block.type === BLOCK_NAME.NEWLINE;
 export const isContainerBlock = (block: Block): block is ContainerBlock =>
   block.type === BLOCK_NAME.CONTAINER;
+export const isStudentHiddenBlock = (
+  block: Block,
+): block is StudentHiddenBlock => block.type === BLOCK_NAME.STUDENT_HIDDEN;

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -64,6 +64,7 @@ import { InsertionPlace } from "./commands";
 import { deleteSelection } from "./commands/commands";
 import { Mapping } from "./mapping";
 import { ProgressBar } from "./progressBar";
+import { studentHiddenPlugin } from "./student-hidden";
 
 /** Type that contains a diagnostics object fit for use in the ProseMirror editor context. */
 export type DiagnosticObjectProse = {
@@ -365,6 +366,7 @@ export class WaterproofEditor implements MessageHandlerEditor {
       updateStatusPlugin(this),
       mathPlugin,
       switchableViewPlugin(this._editorConfig),
+      studentHiddenPlugin,
       codePlugin(
         this._editorConfig.completions,
         this._editorConfig.symbols,

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,4 +11,4 @@ export {
 } from "./serialization/DocumentSerializer";
 export { Node } from "prosemirror-model";
 export * from "./edit-utils";
-export { wrapInContainer } from "./commands";
+export { wrapInContainer, wrapInStudentHidden } from "./commands";

--- a/src/mapping/nodeUpdate.ts
+++ b/src/mapping/nodeUpdate.ts
@@ -47,6 +47,11 @@ export class NodeUpdate {
           this.tagConf.container.openTag(title),
           this.tagConf.container.closeTag,
         ];
+      case "student_hidden":
+        return [
+          this.tagConf.studentHidden.openTag,
+          this.tagConf.studentHidden.closeTag,
+        ];
       default:
         throw new NodeUpdateError(`Unsupported node type: ${nodeName}`);
     }
@@ -531,15 +536,16 @@ export class NodeUpdate {
       );
     }
 
-    // Check that the wrapping node is of a supported type (hint, input, or container)
+    // Check that the wrapping node is of a supported type (hint, input, container, or student_hidden)
     const insertedNodeType = wrappingNode.type.name;
     if (
       insertedNodeType !== "hint" &&
       insertedNodeType !== "input" &&
-      insertedNodeType !== "container"
+      insertedNodeType !== "container" &&
+      insertedNodeType !== "student_hidden"
     ) {
       throw new NodeUpdateError(
-        " We only support wrapping in hints, inputs, or containers ",
+        " We only support wrapping in hints, inputs, containers, or student-hidden nodes ",
       );
     }
 

--- a/src/markdown-defaults/index.ts
+++ b/src/markdown-defaults/index.ts
@@ -42,5 +42,11 @@ export function configuration(languageId: string): TagConfiguration {
       openRequiresNewline: false,
       closeRequiresNewline: false,
     },
+    studentHidden: {
+      openTag: "<student-hidden>",
+      closeTag: "</student-hidden>",
+      openRequiresNewline: false,
+      closeRequiresNewline: false,
+    },
   };
 }

--- a/src/markdown-defaults/statemachine.ts
+++ b/src/markdown-defaults/statemachine.ts
@@ -7,6 +7,7 @@ import {
   MarkdownBlock,
   MathDisplayBlock,
   NewlineBlock,
+  StudentHiddenBlock,
 } from "../document";
 
 enum ParserState {
@@ -21,20 +22,23 @@ enum ParserState {
 }
 
 enum NestedState {
-  /** Not in a hint or an input area */
+  /** Not in a hint, input area, or student-hidden block */
   None,
   /** Parsing as part of a hint */
   Hint,
   /** Parsing as part of an input area */
   Input,
+  /** Parsing as part of a student-hidden block */
+  StudentHidden,
 }
 
 /**
  * Parser for markdown documents.
  *
- * Next to the regular markdown and code parts this parser has predefined 'tags' for hints and input areas:
+ * Next to the regular markdown and code parts this parser has predefined 'tags' for hints, input areas, and student-hidden blocks:
  * * The content between `<hint title="{title}">` and ` </hint>` is turned into a hint cell, `{title}` will turn into the title that is displayed in the editor.
  * * The content between `<input-area>` and `</input-area>` is turned into an input area.
+ * * The content between `<student-hidden>` and `</student-hidden>` is turned into a student-hidden block (only visible in teacher mode).
  * @param document The document to convert into a `WaterproofDocument`
  * @param config An object that may contain
  * - `language: string`: The language tag to use for the code cells. That is, the part of the ` ``` ` when opening a code block (` ```python ` for a python
@@ -89,6 +93,10 @@ export function parse(
     inputAreaOpenLength = inputAreaOpen.length;
   const inputAreaClose = "</input-area>",
     inputAreaCloseLength = inputAreaClose.length;
+  const studentHiddenOpen = "<student-hidden>",
+    studentHiddenOpenLength = studentHiddenOpen.length;
+  const studentHiddenClose = "</student-hidden>",
+    studentHiddenCloseLength = studentHiddenClose.length;
   const codeBlockOpen = "```" + language + "\n",
     codeBlockOpenLength = codeBlockOpen.length;
   const codeBlockClose = "\n```",
@@ -164,6 +172,10 @@ export function parse(
     return lookAhead(inputAreaOpen);
   }
 
+  function opensStudentHiddenBlock(): boolean {
+    return lookAhead(studentHiddenOpen);
+  }
+
   function opensLaTeXBlock(): boolean {
     return lookAhead(latexBlockOpenClose);
   }
@@ -186,6 +198,10 @@ export function parse(
 
   function closesInputAreaBlock(): boolean {
     return lookAhead(inputAreaClose);
+  }
+
+  function closesStudentHiddenBlock(): boolean {
+    return lookAhead(studentHiddenClose);
   }
 
   function closesLaTeXBlock(): boolean {
@@ -258,6 +274,15 @@ export function parse(
       innerRangeStartNested = i;
       rangeStartNested = i;
       nested = NestedState.Input;
+    } else if (nested === NestedState.None && opensStudentHiddenBlock()) {
+      closeMarkdown();
+      setRangeStart();
+      i += studentHiddenOpenLength;
+      setInnerRangeStart();
+      setLineStart();
+      innerRangeStartNested = i;
+      rangeStartNested = i;
+      nested = NestedState.StudentHidden;
     } else if (nested === NestedState.Hint && closesHintBlock()) {
       closeMarkdown();
       nested = NestedState.None;
@@ -289,6 +314,24 @@ export function parse(
       );
       pushBlock(inputAreaBlock);
       i += inputAreaCloseLength; // Skip the </input-area>
+      backToMarkdown(true);
+    } else if (
+      nested === NestedState.StudentHidden &&
+      closesStudentHiddenBlock()
+    ) {
+      closeMarkdown();
+      nested = NestedState.None;
+      const range = { from: getRangeStart(), to: i + studentHiddenCloseLength };
+      const innerRange = { from: getInnerRangeStart(), to: i };
+      const studentHiddenBlock = new StudentHiddenBlock(
+        document.slice(innerRange.from, innerRange.to),
+        range,
+        innerRange,
+        0,
+        innerBlocks,
+      );
+      pushBlock(studentHiddenBlock);
+      i += studentHiddenCloseLength; // Skip the </student-hidden>
       backToMarkdown(true);
     } else {
       checkNewlineAndIncrementI();

--- a/src/menubar/menubar.ts
+++ b/src/menubar/menubar.ts
@@ -12,6 +12,7 @@ import {
   InsertionPlace,
   wrapInHint,
   wrapInInput,
+  wrapInStudentHidden,
   deleteSelection,
   wpLift,
 } from "../commands";
@@ -258,8 +259,14 @@ function createDefaultMenu(
       teacherOnly,
     ),
     createMenuItem(
+      "👁️",
+      "Make selection a student-hidden block (only visible in teacher mode)",
+      teacherOnlyWrapper(wrapInStudentHidden(tagConf)),
+      teacherOnly,
+    ),
+    createMenuItem(
       "↑",
-      "Lift selected node (Reverts the effect of making a 'hint' or 'input area')",
+      "Lift selected node (Reverts the effect of making a 'hint', 'input area', or 'student-hidden' block)",
       teacherOnlyWrapper(wpLift(tagConf)),
       teacherOnly,
     ),

--- a/src/schema/schema.ts
+++ b/src/schema/schema.ts
@@ -8,6 +8,7 @@ export const SchemaCell = {
   Code: "code",
   Newline: "newline",
   Container: "container",
+  StudentHidden: "student_hidden",
 } as const;
 
 export type SchemaKeys = keyof typeof SchemaCell;
@@ -128,5 +129,13 @@ export const WaterproofSchema = new Schema<SchemaNames | "doc" | "text">({
       },
     },
     //#endregion
+
+    student_hidden: {
+      content: "containercontent+",
+      group: "cell",
+      toDOM() {
+        return ["div", {}, 0];
+      },
+    },
   },
 });

--- a/src/serialization/DocumentSerializer.ts
+++ b/src/serialization/DocumentSerializer.ts
@@ -126,6 +126,22 @@ export abstract class DocumentSerializer {
     },
   ): string;
 
+  /**
+   * Describes how to turn a student-hidden node into a string representation.
+   * This node can have children (including input areas and hints), so you probably want to call `this.serializeNode` on every child node.
+   * @param studentHiddenNode The student-hidden node that is going to be serialized
+   * @param parentNode The parent node of this node (if it has one)
+   * @param neighbors Function that upon calling will return the neighbors of the node being serialized.
+   */
+  abstract serializeStudentHidden(
+    studentHiddenNode: Node,
+    parentNode: string | null,
+    neighbors: (skipNewlines: boolean) => {
+      nodeAbove: string | null;
+      nodeBelow: string | null;
+    },
+  ): string;
+
   serializeText(node: Node): string {
     return node.textContent;
   }
@@ -163,6 +179,8 @@ export abstract class DocumentSerializer {
         return this.serializeHint(node, parent, neighbors);
       case WaterproofSchema.nodes.container:
         return this.serializeContainer(node, parent, neighbors);
+      case WaterproofSchema.nodes.student_hidden:
+        return this.serializeStudentHidden(node, parent, neighbors);
       case WaterproofSchema.nodes.text:
         return this.serializeText(node);
       case WaterproofSchema.nodes.newline:
@@ -275,6 +293,14 @@ export class DefaultTagSerializer extends DocumentSerializer {
       this.tagConf.container.openTag(name) +
       this.serializeFragment(node.content, "container") +
       this.tagConf.container.closeTag
+    );
+  }
+
+  serializeStudentHidden(node: Node): string {
+    return (
+      this.tagConf.studentHidden.openTag +
+      this.serializeFragment(node.content, "student_hidden") +
+      this.tagConf.studentHidden.closeTag
     );
   }
 }

--- a/src/student-hidden/index.ts
+++ b/src/student-hidden/index.ts
@@ -1,0 +1,1 @@
+export * from "./plugin";

--- a/src/student-hidden/plugin.ts
+++ b/src/student-hidden/plugin.ts
@@ -14,7 +14,7 @@ export const studentHiddenPlugin = new Plugin({
     decorations(state: EditorState) {
       const teacher = INPUT_AREA_PLUGIN_KEY.getState(state)?.teacher ?? false;
 
-      // We are in student mode, prepare decorations.
+      // Decorate every student_hidden node with a class based on the current mode.
       const decos: Array<Decoration> = [];
 
       state.doc.descendants((node, pos) => {

--- a/src/student-hidden/plugin.ts
+++ b/src/student-hidden/plugin.ts
@@ -1,0 +1,36 @@
+import { EditorState, Plugin, PluginKey } from "prosemirror-state";
+import { INPUT_AREA_PLUGIN_KEY } from "../inputArea";
+import { Decoration, DecorationSet } from "prosemirror-view";
+import { WaterproofSchema } from "../schema";
+
+export const STUDENT_HIDDEN_PLUGIN_KEY = new PluginKey(
+  "waterproof-student-hidden-plugin",
+);
+
+export const studentHiddenPlugin = new Plugin({
+  key: STUDENT_HIDDEN_PLUGIN_KEY,
+
+  props: {
+    decorations(state: EditorState) {
+      const teacher = INPUT_AREA_PLUGIN_KEY.getState(state)?.teacher ?? false;
+
+      // We are in student mode, prepare decorations.
+      const decos: Array<Decoration> = [];
+
+      state.doc.descendants((node, pos) => {
+        if (node.type === WaterproofSchema.nodes.student_hidden) {
+          decos.push(
+            Decoration.node(pos, pos + node.nodeSize, {
+              class: teacher
+                ? "student-hidden-teacher"
+                : "student-hidden-student",
+            }),
+          );
+          return false;
+        }
+      });
+
+      return DecorationSet.create(state.doc, decos);
+    },
+  },
+});

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -41,3 +41,5 @@ import "./magic.css";
 
 // For the busy indicator in the gutter:
 import "./busy-indicator.css";
+
+import "./student-hidden.css";

--- a/src/styles/student-hidden.css
+++ b/src/styles/student-hidden.css
@@ -1,0 +1,15 @@
+/* Class that is added to the student-hidden node when in student mode */
+.student-hidden-student {
+  display: none !important;
+}
+
+/* Class that is added to the student-hidden node when in teacher mode */
+.student-hidden-teacher {
+  border-right: 3px dashed var(--wp-buttonForeground);
+}
+.student-hidden-teacher::after {
+  content: "\1f441\fe0f";
+  position: absolute;
+  top: 0;
+  right: 0.5rem;
+}

--- a/src/styles/student-hidden.css
+++ b/src/styles/student-hidden.css
@@ -5,7 +5,8 @@
 
 /* Class that is added to the student-hidden node when in teacher mode */
 .student-hidden-teacher {
-  border-right: 3px dashed var(--wp-buttonForeground);
+  border-right: 3px dashed var(--wp-buttonBackground);
+  position: relative;
 }
 .student-hidden-teacher::after {
   content: "\1f441\fe0f";


### PR DESCRIPTION
Add a `studentHidden` node and block that is only visible in teacher mode.

When in teacher mode, the student hidden blocks are shown with a white dashed border on the right side and a little 👁️ emoticon to indicate that this cell is not visible to students.


Test in conjunction with:
- https://github.com/impermeable/waterproof-vscode/pull/397
- https://github.com/impermeable/waterproof-genre/pull/6