### PR TITLE
Rename updateLockingState API

### DIFF
--- a/src/api/MessageHandlerEditor.ts
+++ b/src/api/MessageHandlerEditor.ts
@@ -18,7 +18,7 @@ export interface MessageHandlerEditor {
   setShowLineNumbers: (show: boolean) => void;
   setShowMenuItems: (show: boolean) => void;
   handleHistoryChange: (historyChange: HistoryChange) => void;
-  updateLockingState: (teacherModeEnabled: boolean) => void;
+  setTeacherMode: (teacherModeEnabled: boolean) => void;
   refreshDocument: (content: string, version: number) => void;
   removeBusyIndicators: () => void;
   reportProgress: (at: number, numberOfLines: number, label: string) => void;

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -683,11 +683,14 @@ export class WaterproofEditor implements MessageHandlerEditor {
   }
 
   /**
-   * Called whenever a message describing the configuration of user is sent
+   * Updates the teacher mode.
+   *
+   * When in teacher mode, content outside of input areas becomes editable and other
+   * teacher only functionalities are enabled.
    *
    * @param isTeacher Whether teacher mode is enabled
    */
-  public updateLockingState(isTeacher: boolean): void {
+  public setTeacherMode(isTeacher: boolean): void {
     if (!this._view) return;
     const state = this._view.state;
     const trans = state.tr;


### PR DESCRIPTION
Renames `updateLockingState` API on `WaterproofEditor` to the more descriptive `setTeacherMode`

Resolves #2 

Test in conjunction with https://github.com/impermeable/waterproof-vscode/pull/402